### PR TITLE
NATS Streaming API changes for Swan lake

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,9 @@ Ballerina NATS Streaming Library
 The stan library is one of the standard library modules of the<a target="_blank" href="https://ballerina.io/"> Ballerina
 </a> language.
 
-For more information on the operations supported by the module, which include the below, go to [The NATS Module](https://ballerina.io/swan-lake/learn/api-docs/ballerina/stan/).
-
 - Point to point communication (Queues)
 - Pub/Sub (Topics)
 - Request/Reply
-
-For example demonstrations of the usage, go to [Ballerina By Examples](https://ballerina.io/swan-lake/learn/by-example/stan-basic-client.html).
 
 ## Issues and Projects 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=1.0.0-SNAPSHOT
-ballerinaLangVersion=2.0.0-Preview7-SNAPSHOT
+ballerinaLangVersion=2.0.0-Preview8-SNAPSHOT
 
 puppycrawlCheckstyleVersion=8.18
 
-stdlibCryptoVersion=1.0.3-SNAPSHOT
-stdlibLogVersion=1.0.3-SNAPSHOT
-stdlibTimeVersion=1.0.4-SNAPSHOT
-stdlibSystemVersion=0.6.3-SNAPSHOT
-stdlibRuntimeVersion=0.5.3-SNAPSHOT
-stdlibIoVersion=0.5.3-SNAPSHOT
+stdlibCryptoVersion=1.0.4-SNAPSHOT
+stdlibLogVersion=1.0.4-SNAPSHOT
+stdlibTimeVersion=1.0.5-SNAPSHOT
+stdlibSystemVersion=0.6.4-SNAPSHOT
+stdlibRuntimeVersion=0.5.4-SNAPSHOT
+stdlibIoVersion=0.5.4-SNAPSHOT

--- a/stan-ballerina/Package.md
+++ b/stan-ballerina/Package.md
@@ -1,6 +1,6 @@
 ## Module Overview
 
-This module provides the capability to connect with NATS and NATS Streaming servers and performs the 
+This module provides the capability to connect with NATS Streaming server and performs the 
 below functionalities.
 
 - Point to point communication (Queues)
@@ -11,151 +11,60 @@ below functionalities.
 
 #### Setting up the connection
 
-First step is setting up the connection with the NATS Basic/Streaming server. The following ways can be used to connect to a
-NATS Basic/Streaming server.
+First step is setting up the connection with the NATS Streaming server. The following ways can be used to connect to a
+NATS Streaming server.
 
 1. Connect to a server using the URL
 ```ballerina
-nats:Connection connection = new("nats://localhost:4222");
+stan:Client newClient = new("nats://localhost:4222");
 ```
 
 2. Connect to one or more servers with a custom configuration
 ```ballerina
-nats:Connection connection = new("nats://serverone:4222, nats://servertwo:4222",  config);
+stan:Client newClient = new({"nats://serverone:4222", "nats://servertwo:4222"},  config);
 ```
 
 #### Publishing messages
 
 Publishing messages is handled differently in the NATS Basic server and Streaming server. The 'ballerina/nats' module provides different 
-APIs to publish messages to each server.
+APIs to publish messages to NATS Streaming server.
 
-##### Publishing messages to the NATS basic server
+##### Publishing messages to the NATS Streaming server
 
 Once connected, publishing is accomplished via one of the below two methods.
 
 1. Publish with the subject and the message content.
 ```ballerina
-nats:Producer producer = new(connection);
-nats:Error? result = producer->publish(subject, "hello world");
+string message = "hello world";
+stan:Error? result = producer->publish(subject, message.toBytes());
 ```
-
-2. Publish as a request that expects a reply.
-```ballerina
-nats:Producer producer = new(connection);
-nats:Message|nats:Error reqReply = producer->request(subject, "hello world", 5000);
-```
-
-3. Publish messages with a replyTo subject 
-```ballerina
-nats:Producer producer = new(connection);
-nats:Error? result = producer->publish(subject, <@untainted>message, 
-                         replyToSubject);
-```
-
-4. Publish messages with a replyTo callback service
-```ballerina
-nats:Producer producer = new(connection);
-nats:Error? result = producer->publish(subject, <@untainted>message, 
-                         replyToService);
-```
-```ballerina
-service replyToService =
-@nats:SubscriptionConfig {
-    subject: "replySubject"
-}
-service {
-
-    resource function onMessage(nats:Message msg, string data) {
-    }
-
-    resource function onError(nats:Message msg, nats:Error err) {
-    }
-};
-```
-
-##### Publishing messages to a NATS streaming server
-
-Once connected to a streaming server, publishing messages is accomplished using the following method.
-```ballerina
-nats:StreamingProducer producer = new(connection);
-string|error result = producer->publish(subject, "hello world");
-```
-
-> Publish api supports the `byte[], boolean, string, int, float, decimal, xml, json, record {}` message types.
-
 
 #### Listening to incoming messages
-
-The Ballerina NATS module provides the following mechanisms to listen to messages. Similar to message publishing, listening to messages
-is also handled differently in the NATS basic and streaming servers.
-
-##### Listening to messages from a NATS server
-
-```ballerina
-// Initializes the NATS listener.
-listener nats:Listener subscription = new(connection);
-
-// Binds the consumer to listen to the messages published to the 'demo' subject.
-@nats:SubscriptionConfig {
-    subject: "demo"
-}
-service demo on subscription {
-
-    resource function onMessage(nats:Message msg, string data) {
-    }
-
-    resource function onError(nats:Message msg, nats:Error err) {
-    }
-}
-```
 
 ##### Listening to messages from a Streaming server
 
 ```ballerina
 // Initializes the NATS Streaming listener.
-listener nats:StreamingListener subscription = new(conn, "test-cluster", "c1");
+listener stan:Listener subscription = new;
 
 // Binds the consumer to listen to the messages published to the 'demo' subject.
-@nats:StreamingSubscriptionConfig {
+@stan:ServiceConfig {
     subject: "demo"
 }
 service demo on subscription {
 
-    resource function onMessage(nats:StreamingMessage msg, string data) {
+    resource function onMessage(stan:Message msg, stan:Caller caller) {
     }
 
-    resource function onError(nats:StreamingMessage msg, nats:Error err) {
-    }
 
 }
 ```
 
-### Advanced Usage
-
-#### Using the TLS protocol
-
-The Ballerina NATS module allows the use of the tls:// protocol in its URLs. This setting expects a secure socket to be 
-set in the connection configuration as shown below.
-
-```ballerina
-nats:ConnectionConfig config = {
-    secureSocket : {
-        trustStore : {
-            path: "nats-basic/keyStore.p12",
-            password: "xxxxx"
-        }
-    }
-};
-
-// Initializes a connection.
-nats:Connection connection = new("tls://localhost:4222", config = config);
-```
 >**Note:** The default thread pool size used in Ballerina is the number of processors available * 2. You can configure the thread pool size by using the `BALLERINA_MAX_POOL_SIZE` environment variable.
 
 For information on the operations, which you can perform with this module, see the below **Functions**. 
 
 For examples on the usage of the connector, see the following.
-* [Basic Publisher and Subscriber Example](https://ballerina.io/swan-lake/learn/by-example/nats-basic-client.html).
 * [Basic Streaming Publisher and Subscriber Example](https://ballerina.io/swan-lake/learn/by-example/nats-streaming-client.html)
 * [Streaming Publisher and Subscriber With Data Binding Example](https://ballerina.io/swan-lake/learn/by-example/nats-streaming-consumer-with-data-binding.html)
 * [Durable Subscriptions Example](https://ballerina.io/swan-lake/learn/by-example/nats-streaming-durable-subscriptions.html)

--- a/stan-ballerina/annotation.bal
+++ b/stan-ballerina/annotation.bal
@@ -40,7 +40,7 @@ public type ServiceConfigData record {|
 |};
 
 # The annotation, which is used to configure the streaming subscription.
-public annotation ServiceConfigData ServiceConfig on service;
+public annotation ServiceConfigData ServiceConfig on service, class;
 
 # Specifies that message delivery should start with the messages, which are published after the subscription is created.
 public const NEW_ONLY = "NEW_ONLY";

--- a/stan-ballerina/build.gradle
+++ b/stan-ballerina/build.gradle
@@ -155,19 +155,19 @@ task startNatsServer() {
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             def stdOut = new ByteArrayOutputStream()
             exec {
-                commandLine 'sh', '-c', "docker ps --filter name=my-nats"
+                commandLine 'sh', '-c', "docker ps --filter name=my-stan"
                 standardOutput = stdOut
             }
-            if (!stdOut.toString().contains("my-nats")) {
+            if (!stdOut.toString().contains("my-stan")) {
                 println "Starting NATS Basic server."
                 exec {
-                    commandLine 'sh', '-c', "docker run --rm -d --name my-nats -p 4222:4222 nats:latest"
+                    commandLine 'sh', '-c', "docker run --rm -d --name my-stan -p 4222:4222 nats-streaming"
                     standardOutput = stdOut
                 }
                 println stdOut.toString()
                 sleep(5 * 1000)
             } else {
-                println "NATS Basic server is already started."
+                println "NATS Streaming server is already started."
             }
         }
     }
@@ -178,13 +178,13 @@ task stopNatsServer() {
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             def stdOut = new ByteArrayOutputStream()
             exec {
-                commandLine 'sh', '-c', "docker ps --filter name=my-nats"
+                commandLine 'sh', '-c', "docker ps --filter name=my-stan"
                 standardOutput = stdOut
             }
-            if (stdOut.toString().contains("my-nats")) {
+            if (stdOut.toString().contains("my-stan")) {
                 println "Stopping NATS server."
                 exec {
-                    commandLine 'sh', '-c', "docker stop my-nats"
+                    commandLine 'sh', '-c', "docker stop my-stan"
                     standardOutput = stdOut
                 }
                 println stdOut.toString()

--- a/stan-ballerina/caller.bal
+++ b/stan-ballerina/caller.bal
@@ -22,7 +22,7 @@ public client class Caller {
    # Acknowledges the NATS streaming server upon the receipt of the message.
    #
    # + return - `()` or else a `nats:Error` upon failure to acknowledge the server
-   public isolated remote function ack() returns Error? {
+   isolated remote function ack() returns Error? {
        return externAck(self);
    }
 }

--- a/stan-ballerina/caller.bal
+++ b/stan-ballerina/caller.bal
@@ -16,7 +16,7 @@
 
 import ballerina/java;
 
-# Represents the message a NATS Streaming Server sends to its subscribed services.
+# Represents the NATS caller.
 public client class Caller {
 
    # Acknowledges the NATS streaming server upon the receipt of the message.

--- a/stan-ballerina/client.bal
+++ b/stan-ballerina/client.bal
@@ -27,7 +27,7 @@ public client class Client {
     # + clientId - A unique identifier of the client
     # + clusterId - The unique identifier of the cluster configured in the NATS server
     # + streamingConfig - The configuration related to the NATS streaming connectivity
-    public isolated function init(string url = DEFAULT_URL, string? clientId = (), string clusterId = "test-cluster",
+    isolated function init(string url = DEFAULT_URL, string? clientId = (), string clusterId = "test-cluster",
     StreamingConfig? connectionConfig = ()) {
         streamingProducerInit(self, url, clusterId, clientId, connectionConfig);
     }
@@ -43,7 +43,7 @@ public client class Client {
     #            elapses while waiting for the acknowledgement, or else
     #            a `nats:Error` only with the `message` field in case an error occurs even before publishing
     #            is completed
-    public isolated remote function publish(string subject,@untainted byte[] data) returns string|Error {
+    isolated remote function publish(string subject,@untainted byte[] data) returns string|Error {
         return externStreamingPublish(self, subject, data);
 
     }

--- a/stan-ballerina/client.bal
+++ b/stan-ballerina/client.bal
@@ -16,11 +16,10 @@
 
 import ballerina/java;
 
-# The streaming producer provides the capability to publish messages to the NATS streaming server.
-# The `nats:StreamingProducer` needs the `nats:Connection` to be initialized.
+# The streaming client provides the capability to publish messages to the NATS streaming server.
 public client class Client {
 
-    # Creates a new `nats:StreamingProducer` instance.
+    # Creates a new `stan:Client` instance.
     #
     # + url -  The NATS Broker URL. For a clustered use case, pass the URL
     #                       as a string array.
@@ -33,15 +32,15 @@ public client class Client {
     }
 
     # Publishes data to a given subject.
-    # ```ballerina string|error result = producer->publish(subject, <@untainted>message);```
+    # ```ballerina string|error result = newClient->publish(subject, <@untainted>message.toBytes());```
     #
     # + subject - The subject to send the message 
     # + data - Data to publish
     # + return - The `string` value representing the NUID (NATS Unique Identifier) of the published message if the
     #            message gets successfully published and acknowledged by the NATS server,
-    #            a `nats:Error` with NUID and `message` fields in case an error occurs in publishing, the timeout
+    #            a `stan:Error` with NUID and `message` fields in case an error occurs in publishing, the timeout
     #            elapses while waiting for the acknowledgement, or else
-    #            a `nats:Error` only with the `message` field in case an error occurs even before publishing
+    #            a `stan:Error` only with the `message` field in case an error occurs even before publishing
     #            is completed
     isolated remote function publish(string subject,@untainted byte[] data) returns string|Error {
         return externStreamingPublish(self, subject, data);
@@ -50,7 +49,7 @@ public client class Client {
 
     # Close the producer.
     #
-    # + return - `()` or else a `nats:Error` if unable to complete the close operation.
+    # + return - `()` or else a `stan:Error` if unable to complete the close operation.
     public isolated function close() returns error? {
         return streamingProducerClose(self);
     }

--- a/stan-ballerina/client.bal
+++ b/stan-ballerina/client.bal
@@ -26,7 +26,7 @@ public client class Client {
     # + clientId - A unique identifier of the client
     # + clusterId - The unique identifier of the cluster configured in the NATS server
     # + streamingConfig - The configuration related to the NATS streaming connectivity
-    isolated function init(string url = DEFAULT_URL, string? clientId = (), string clusterId = "test-cluster",
+    public isolated function init(string url = DEFAULT_URL, string? clientId = (), string clusterId = "test-cluster",
     StreamingConfig? connectionConfig = ()) {
         streamingProducerInit(self, url, clusterId, clientId, connectionConfig);
     }

--- a/stan-ballerina/error.bal
+++ b/stan-ballerina/error.bal
@@ -15,10 +15,10 @@
 // under the License.
 
 # Represents the NATS module related errors.
-public type NatsError distinct error;
+public type StanError distinct error;
 
 # The union of the NATS module related errors.
-public type Error NatsError;
+public type Error StanError;
 
 # Prepare the `error` as a `Error`.
 #
@@ -26,11 +26,11 @@ public type Error NatsError;
 # + err - The `error` instance
 # + return - Prepared `nats:Error` instance
 isolated function prepareError(string message, error? err = ()) returns Error {
-    NatsError natsError;
+    StanError stanError;
     if (err is error) {
-        natsError = NatsError(message, err);
+        stanError = StanError(message, err);
     } else {
-        natsError = NatsError(message);
+        stanError = StanError(message);
     }
-    return natsError;
+    return stanError;
 }

--- a/stan-ballerina/listener.bal
+++ b/stan-ballerina/listener.bal
@@ -14,14 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/lang.'object as lang;
 import ballerina/java;
 
 # Represents the NATS streaming server connection to which a subscription service should be bound in order to
 # receive messages of the corresponding subscription.
 public class Listener {
-
-    *lang:Listener;
 
     private string url;
     private string clusterId;
@@ -50,7 +47,7 @@ public class Listener {
     # + s - Type descriptor of the service
     # + name - Name of the service
     # + return - `()` or else a `nats:Error` upon failure to register the listener
-    public isolated function __attach(service s, string? name = ()) returns error? {
+    public isolated function attach(StanService s, string|string[]? name = ()) returns error? {
         streamingAttach(self, s, self.url);
     }
 
@@ -58,28 +55,28 @@ public class Listener {
     #
     # + s - Type descriptor of the service
     # + return - `()` or else a `nats:Error` upon failure to detach the service
-    public isolated function __detach(service s) returns error? {
+    public isolated function detach(StanService s) returns error? {
         streamingDetach(self, s);
     }
 
     # Starts the `nats:Listener`.
     #
     # + return - `()` or else a `nats:Error` upon failure to start the listener
-    public isolated function __start() returns error? {
+    public isolated function 'start() returns error? {
          streamingSubscribe(self, self.url, self.clusterId, self.clientId, self.streamingConfig);
     }
 
     # Stops the `nats:Listener` gracefully.
     #
     # + return - `()` or else a `nats:Error` upon failure to stop the listener
-    public isolated function __gracefulStop() returns error? {
+    public isolated function gracefulStop() returns error? {
         return ();
     }
 
     # Stops the `nats:Listener` forcefully.
     #
     # + return - `()` or else a `nats:Error` upon failure to stop the listener
-    public isolated function __immediateStop() returns error? {
+    public isolated function immediateStop() returns error? {
         return self.close();
     }
 
@@ -99,12 +96,12 @@ isolated function streamingSubscribe(Listener streamingClient, string conn,
     'class: "org.ballerinalang.nats.streaming.consumer.Subscribe"
 } external;
 
-isolated function streamingAttach(Listener lis, service serviceType, string conn) =
+isolated function streamingAttach(Listener lis, StanService serviceType, string conn) =
 @java:Method {
     'class: "org.ballerinalang.nats.streaming.consumer.Attach"
 } external;
 
-isolated function streamingDetach(Listener lis, service serviceType) =
+isolated function streamingDetach(Listener lis, StanService serviceType) =
 @java:Method {
     'class: "org.ballerinalang.nats.streaming.consumer.Detach"
 } external;
@@ -113,3 +110,8 @@ isolated function streamingListenerClose(Listener lis) returns error? =
 @java:Method {
     'class: "org.ballerinalang.nats.streaming.consumer.Close"
 } external;
+
+# The STAN service type
+public type StanService service object {
+    // TBD when support for optional params in remote functions is available in lang
+};

--- a/stan-ballerina/listener.bal
+++ b/stan-ballerina/listener.bal
@@ -47,7 +47,7 @@ public class Listener {
     # + s - Type descriptor of the service
     # + name - Name of the service
     # + return - `()` or else a `nats:Error` upon failure to register the listener
-    public isolated function attach(StanService s, string|string[]? name = ()) returns error? {
+    public isolated function attach(Service s, string|string[]? name = ()) returns error? {
         streamingAttach(self, s, self.url);
     }
 
@@ -55,7 +55,7 @@ public class Listener {
     #
     # + s - Type descriptor of the service
     # + return - `()` or else a `nats:Error` upon failure to detach the service
-    public isolated function detach(StanService s) returns error? {
+    public isolated function detach(Service s) returns error? {
         streamingDetach(self, s);
     }
 
@@ -96,12 +96,12 @@ isolated function streamingSubscribe(Listener streamingClient, string conn,
     'class: "org.ballerinalang.nats.streaming.consumer.Subscribe"
 } external;
 
-isolated function streamingAttach(Listener lis, StanService serviceType, string conn) =
+isolated function streamingAttach(Listener lis, Service serviceType, string conn) =
 @java:Method {
     'class: "org.ballerinalang.nats.streaming.consumer.Attach"
 } external;
 
-isolated function streamingDetach(Listener lis, StanService serviceType) =
+isolated function streamingDetach(Listener lis, Service serviceType) =
 @java:Method {
     'class: "org.ballerinalang.nats.streaming.consumer.Detach"
 } external;
@@ -112,6 +112,6 @@ isolated function streamingListenerClose(Listener lis) returns error? =
 } external;
 
 # The STAN service type
-public type StanService service object {
+public type Service service object {
     // TBD when support for optional params in remote functions is available in lang
 };

--- a/stan-ballerina/tests/nats_basic_server_tests.bal
+++ b/stan-ballerina/tests/nats_basic_server_tests.bal
@@ -1,92 +1,88 @@
-//// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-////
-//// WSO2 Inc. licenses this file to you under the Apache License,
-//// Version 2.0 (the "License"); you may not use this file except
-//// in compliance with the License.
-//// You may obtain a copy of the License at
-////
-//// http://www.apache.org/licenses/LICENSE-2.0
-////
-//// Unless required by applicable law or agreed to in writing,
-//// software distributed under the License is distributed on an
-//// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-//// KIND, either express or implied. See the License for the
-//// specific language governing permissions and limitations
-//// under the License.
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
-//import ballerina/log;
-//import ballerina/runtime;
-//import ballerina/test;
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
 //
-//Connection? basicConnection = ();
-//const SUBJECT_NAME = "nats-basic";
-//const SERVICE_SUBJECT_NAME = "nats-basic-service";
-//string receivedConsumerMessage = "";
+// http://www.apache.org/licenses/LICENSE-2.0
 //
-//@test:BeforeSuite
-//function setup() {
-//    log:printInfo("Creating a ballerina NATS connection.");
-//    Connection newConnection = new(["nats://localhost:4222"]);
-//    basicConnection = newConnection;
-//}
-//
-//@test:Config {
-//    groups: ["nats-basic"]
-//}
-//public function testConnection() {
-//    boolean flag = false;
-//    Connection? con = basicConnection;
-//    if (con is Connection) {
-//        flag = true;
-//    }
-//    test:assertTrue(flag, msg = "NATS Connection creation failed.");
-//}
-//
-//@test:Config {
-//    dependsOn: ["testConnection"],
-//    groups: ["nats-basic"]
-//}
-//public function testProducer() {
-//    Connection? con = basicConnection;
-//    if (con is Connection) {
-//        Producer producer = new(con);
-//        Error? result = producer->publish(SUBJECT_NAME, "Hello World");
-//        test:assertEquals(result, (), msg = "Producing a message to the broker caused an error.");
-//    } else {
-//        test:assertFail("NATS Connection creation failed.");
-//    }
-//}
-//
-//@test:Config {
-//    dependsOn: ["testProducer"],
-//    groups: ["nats-basic"]
-//}
-//public function testConsumerService() {
-//    string message = "Testing Consumer Service";
-//    Connection? con = basicConnection;
-//    if (con is Connection) {
-//        Listener sub = new(con);
-//        Producer producer = new(con);
-//        checkpanic sub.__attach(consumerService);
-//        checkpanic sub.__start();
-//        checkpanic producer->publish(SERVICE_SUBJECT_NAME, message);
-//        runtime:sleep(5000);
-//        test:assertEquals(receivedConsumerMessage, message, msg = "Message received does not match.");
-//    } else {
-//        test:assertFail("NATS Connection creation failed.");
-//    }
-//}
-//
-//service consumerService =
-//@SubscriptionConfig {
-//    subject: SERVICE_SUBJECT_NAME
-//}
-//service {
-//    resource function onMessage(Message msg, string data) {
-//        receivedConsumerMessage = <@untainted> data;
-//        log:printInfo("Message Received: " + receivedConsumerMessage);
-//    }
-//
-//    resource function onError(Message msg, Error err) {
-//    }
-//};
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.'string;
+import ballerina/log;
+import ballerina/runtime;
+import ballerina/test;
+
+Client? clientObj = ();
+const SUBJECT_NAME = "nats-streaming";
+const SERVICE_SUBJECT_NAME = "nats-streaming-service";
+string receivedConsumerMessage = "";
+
+@test:BeforeSuite
+function setup() {
+    log:printInfo("Creating a ballerina NATS connection.");
+    Client newClient = new;
+    clientObj = newClient;
+}
+
+@test:Config {
+    groups: ["nats-basic"]
+}
+public function testConnection() {
+    boolean flag = false;
+    Client? con = clientObj;
+    if (con is Client) {
+        flag = true;
+    }
+    test:assertTrue(flag, msg = "NATS Connection creation failed.");
+}
+
+@test:Config {
+    dependsOn: ["testConnection"],
+    groups: ["nats-basic"]
+}
+public function testProducer() {
+    Client? con = clientObj;
+    if (con is Client) {
+        string message = "Hello World";
+        Error|string result = con->publish(SUBJECT_NAME, message.toBytes());
+        test:assertTrue(result is string, msg = "Producing a message to the broker caused an error.");
+    } else {
+        test:assertFail("NATS Connection creation failed.");
+    }
+}
+
+@test:Config {
+    dependsOn: ["testProducer"],
+    groups: ["nats-basic"]
+}
+public function testConsumerService() {
+    string message = "Testing Consumer Service";
+    Listener sub = new;
+    Client newClient = new;
+    checkpanic sub.attach(consumerService);
+    checkpanic sub.'start();
+    string id = checkpanic newClient->publish(SERVICE_SUBJECT_NAME, message.toBytes());
+    runtime:sleep(5000);
+    test:assertEquals(receivedConsumerMessage, message, msg = "Message received does not match.");
+}
+
+StanService consumerService =
+@ServiceConfig {
+    subject: SERVICE_SUBJECT_NAME
+}
+service object {
+    remote function onMessage(Message msg) {
+        string|error messageContent = 'string:fromBytes(msg.content);
+        if (messageContent is string) {
+            receivedConsumerMessage = <@untainted> messageContent;
+            log:printInfo("Message Received: " + receivedConsumerMessage);
+        }
+    }
+};

--- a/stan-ballerina/tests/nats_streaming_server_tests.bal
+++ b/stan-ballerina/tests/nats_streaming_server_tests.bal
@@ -73,7 +73,7 @@ public function testConsumerService() {
     test:assertEquals(receivedConsumerMessage, message, msg = "Message received does not match.");
 }
 
-StanService consumerService =
+Service consumerService =
 @ServiceConfig {
     subject: SERVICE_SUBJECT_NAME
 }

--- a/stan-ballerina/tests/nats_streaming_server_tests.bal
+++ b/stan-ballerina/tests/nats_streaming_server_tests.bal
@@ -32,7 +32,7 @@ function setup() {
 }
 
 @test:Config {
-    groups: ["nats-basic"]
+    groups: ["nats-streaming"]
 }
 public function testConnection() {
     boolean flag = false;
@@ -45,7 +45,7 @@ public function testConnection() {
 
 @test:Config {
     dependsOn: ["testConnection"],
-    groups: ["nats-basic"]
+    groups: ["nats-streaming"]
 }
 public function testProducer() {
     Client? con = clientObj;
@@ -60,7 +60,7 @@ public function testProducer() {
 
 @test:Config {
     dependsOn: ["testProducer"],
-    groups: ["nats-basic"]
+    groups: ["nats-streaming"]
 }
 public function testConsumerService() {
     string message = "Testing Consumer Service";

--- a/stan-native/src/main/java/org/ballerinalang/nats/Constants.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/Constants.java
@@ -52,14 +52,14 @@ public class Constants {
     // Represent whether connection close already triggered.
     public static final String CLOSING = "closing";
 
-    public static final String NATS = "nats";
+    public static final String NATS = "stan";
     public static final String ORG_NAME = "ballerinax";
-    public static final String VERSION = "1.0.4";
+    public static final String VERSION = "1.0.0";
 
     // Represents nats package.
     public static final String NATS_PACKAGE = ORG_NAME + ORG_NAME_SEPARATOR + NATS + ":" + VERSION;
 
-    public static final Module NATS_PACKAGE_ID = new Module(ORG_NAME, "nats", VERSION);
+    public static final Module NATS_PACKAGE_ID = new Module(ORG_NAME, "stan", VERSION);
 
     // Represents the message which will be consumed from NATS.
     public static final String NATS_MESSAGE_OBJ_NAME = "Message";
@@ -68,7 +68,7 @@ public class Constants {
     public static final String NATS_MSG = "NATSMSG";
 
     // Error code for i/o.
-    static final String NATS_ERROR = "NatsError";
+    static final String NATS_ERROR = "StanError";
 
     // Represents the NATS error detail record.
     static final String NATS_ERROR_DETAIL_RECORD = "Detail";
@@ -87,7 +87,7 @@ public class Constants {
     public static final String NATS_STREAMING_SUBSCRIPTION_ANNOTATION = "ServiceConfig";
     public static final BString NATS_STREAMING_MANUAL_ACK = StringUtils.fromString("autoAck");
 
-    public static final String NATS_STREAMING_MESSAGE_OBJ_NAME = "StreamingMessage";
+    public static final String NATS_STREAMING_MESSAGE_OBJ_NAME = "Message";
 
     public static final String NATS_STREAMING_LISTENER = "StreamingListener";
 
@@ -114,7 +114,7 @@ public class Constants {
     public static final BString KEY_STORE_PATH = StringUtils.fromString("path");
 
     // Error messages and logs.
-    public static final String MODULE = "[ballerina/nats] ";
+    public static final String MODULE = "[ballerinax/stan] ";
     public static final String ERROR_SETTING_UP_SECURED_CONNECTION = "Error while setting up secured connection. ";
     public static final String THREAD_INTERRUPTED_ERROR =
             "Internal error occurred. The current thread got interrupted.";

--- a/stan-native/src/main/java/org/ballerinalang/nats/Utils.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/Utils.java
@@ -18,22 +18,15 @@
 
 package org.ballerinalang.nats;
 
-import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ErrorCreator;
-import io.ballerina.runtime.api.creators.ValueCreator;
-import io.ballerina.runtime.api.types.AttachedFunctionType;
-import io.ballerina.runtime.api.types.StructureType;
+import io.ballerina.runtime.api.types.MemberFunctionType;
 import io.ballerina.runtime.api.types.Type;
-import io.ballerina.runtime.api.utils.JsonUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.utils.TypeUtils;
-import io.ballerina.runtime.api.utils.XmlUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
-import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
-import io.nats.client.Message;
 
 import java.nio.charset.StandardCharsets;
 
@@ -47,66 +40,6 @@ public class Utils {
                                                 StringUtils.fromString(detailedErrorMessage));
     }
 
-    public static Object bindDataToIntendedType(byte[] data, Type intendedType) {
-        int dataParamTypeTag = intendedType.getTag();
-        Object dispatchedData;
-        switch (dataParamTypeTag) {
-            case TypeTags.STRING_TAG:
-                dispatchedData = StringUtils.fromString(new String(data, StandardCharsets.UTF_8));
-                break;
-            case TypeTags.JSON_TAG:
-                try {
-                    Object json = JsonUtils.parse(new String(data, StandardCharsets.UTF_8));
-                    dispatchedData = json instanceof String ? StringUtils.fromString((String) json) : json;
-                } catch (BError e) {
-                    throw createNatsError("Error occurred in converting message content to json: " +
-                            e.getMessage());
-                }
-                break;
-            case TypeTags.INT_TAG:
-                dispatchedData = Integer.valueOf(new String(data, StandardCharsets.UTF_8));
-                break;
-            case TypeTags.BOOLEAN_TAG:
-                dispatchedData = Boolean.valueOf(new String(data, StandardCharsets.UTF_8));
-                break;
-            case TypeTags.FLOAT_TAG:
-                dispatchedData = Double.valueOf(new String(data, StandardCharsets.UTF_8));
-                break;
-            case TypeTags.DECIMAL_TAG:
-                dispatchedData = ValueCreator.createDecimalValue(new String(data, StandardCharsets.UTF_8));
-                break;
-            case TypeTags.ARRAY_TAG:
-                dispatchedData = ValueCreator.createArrayValue(data);
-                break;
-            case TypeTags.XML_TAG:
-                dispatchedData = XmlUtils.parse(new String(data, StandardCharsets.UTF_8));
-                break;
-            case TypeTags.RECORD_TYPE_TAG:
-                dispatchedData = JsonUtils.convertJSONToRecord(JsonUtils.parse(new String(data,
-                        StandardCharsets.UTF_8)), (StructureType) intendedType);
-                break;
-            default:
-                throw Utils.createNatsError("Unable to find a supported data type to bind the message data");
-        }
-        return dispatchedData;
-    }
-
-    public static BObject getMessageObject(Message message) {
-        BObject msgObj;
-        if (message != null) {
-            BArray msgData = ValueCreator.createArrayValue(message.getData());
-            msgObj = ValueCreator.createObjectValue(Constants.NATS_PACKAGE_ID,
-                                                       Constants.NATS_MESSAGE_OBJ_NAME,
-                                                       StringUtils.fromString(message.getSubject()), msgData,
-                                                       StringUtils.fromString(message.getReplyTo()));
-        } else {
-            BArray msgData = ValueCreator.createArrayValue(new byte[0]);
-            msgObj = ValueCreator.createObjectValue(Constants.NATS_PACKAGE_ID,
-                    Constants.NATS_MESSAGE_OBJ_NAME, "", msgData, "");
-        }
-        return msgObj;
-    }
-
     public static byte[] convertDataIntoByteArray(Object data) {
         Type dataType = TypeUtils.getType(data);
         int typeTag = dataType.getTag();
@@ -117,25 +50,16 @@ public class Utils {
         }
     }
 
-    public static AttachedFunctionType getAttachedFunctionType(BObject serviceObject, String functionName) {
-        AttachedFunctionType function = null;
-        AttachedFunctionType[] resourceFunctions = serviceObject.getType().getAttachedFunctions();
-        for (AttachedFunctionType resourceFunction : resourceFunctions) {
+    public static MemberFunctionType getAttachedFunctionType(BObject serviceObject, String functionName) {
+        MemberFunctionType function = null;
+        MemberFunctionType[] resourceFunctions = serviceObject.getType().getAttachedFunctions();
+        for (MemberFunctionType resourceFunction : resourceFunctions) {
             if (functionName.equals(resourceFunction.getName())) {
                 function = resourceFunction;
                 break;
             }
         }
         return function;
-    }
-
-    @SuppressWarnings("unchecked")
-    public static BMap<BString, Object> getSubscriptionConfig(Object annotationData) {
-        BMap annotationRecord = null;
-        if (TypeUtils.getType(annotationData).getTag() == TypeTags.RECORD_TYPE_TAG) {
-            annotationRecord = (BMap) annotationData;
-        }
-        return annotationRecord;
     }
 
     public static String getCommaSeparatedUrl(BObject connectionObject) {

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/BallerinaNatsStreamingConnectionFactory.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/BallerinaNatsStreamingConnectionFactory.java
@@ -59,7 +59,7 @@ public class BallerinaNatsStreamingConnectionFactory {
         opts.clientId(clientId);
         opts.clusterId(clusterId);
 
-        if (TypeUtils.getType(streamingConfig).getTag() == TypeTags.RECORD_TYPE_TAG) {
+        if (streamingConfig != null && TypeUtils.getType(streamingConfig).getTag() == TypeTags.RECORD_TYPE_TAG) {
             opts.connectionListener(new DefaultConnectionListener());
             opts.errorListener(new DefaultErrorListener());
             opts.discoverPrefix(streamingConfig.getStringValue(DISCOVERY_PREFIX).getValue());

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/Attach.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/Attach.java
@@ -23,7 +23,6 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import org.ballerinalang.nats.Constants;
-import org.ballerinalang.nats.observability.NatsMetricsReporter;
 
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -41,11 +40,8 @@ public class Attach {
                 (ConcurrentHashMap<BObject, StreamingListener>) streamingListener
                         .getNativeData(STREAMING_DISPATCHER_LIST);
         boolean manualAck = !getAckMode(service);
-        NatsMetricsReporter natsMetricsReporter =
-                (NatsMetricsReporter) streamingListener.getNativeData(Constants.NATS_METRIC_UTIL);
         serviceListenerMap.put(service, new StreamingListener(service, manualAck, Runtime.getCurrentRuntime(),
-                                                              streamingConnectionUrl.getValue(),
-                                                              natsMetricsReporter));
+                                                              streamingConnectionUrl.getValue()));
     }
 
     private static boolean getAckMode(BObject service) {

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/producer/Init.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/producer/Init.java
@@ -38,9 +38,8 @@ public class Init {
                 NatsStreamingConnection.createConnection(streamingClientObject, url.getValue(), clusterId.getValue(),
                                                                      clientIdNillable, streamingConfig);
         streamingClientObject.addNativeData(Constants.NATS_STREAMING_CONNECTION, connection);
-        NatsMetricsReporter natsMetricsReporter =
-                (NatsMetricsReporter) streamingClientObject.getNativeData(Constants.NATS_METRIC_UTIL);
-        streamingClientObject.addNativeData(Constants.NATS_METRIC_UTIL, new NatsMetricsReporter(connection));
+        NatsMetricsReporter natsMetricsReporter = new NatsMetricsReporter(connection);
+        streamingClientObject.addNativeData(Constants.NATS_METRIC_UTIL, natsMetricsReporter);
         natsMetricsReporter.reportNewProducer();
     }
 }


### PR DESCRIPTION
**Note: Some features are intentionally disabled since the APIs are not finalized for them**

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/667
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/671

## Purpose
Introducing the new API changes and service typing in the NATS Streaming module for Ballerina Swan Lake. The design docs are given below. 

1. [STAN client API changes](https://docs.google.com/document/d/1O_RRExICxYxzBoOpmxayqBRuf_UGzF-4BxVuQ_M7MI8/edit?usp=sharing)
2. [STAN service changes](https://docs.google.com/document/d/1AS1BD0qPdP1E870GKowwvcsoFb8ij9aS78X3y6Zop-Y/edit?usp=sharing) 

## Changes made
- **Remove nats:Connection entirely:** 
Same as ballerinax/nats.

- **Rename nats:StreamingProducer to stan:Client:** 
In all other language libraries, stan Connection is used to call functions (See in comparison), even the subscription/consumer related functions. We have differentiated them because we have the concept of the listener. Also to be consistent with ballerinax/nats. 

- **nats:StreamingMessage is a record:** 
The current nats:StreamingMessage has 2 fields, get methods for those fields and one remote function ack(). nats:StreamingMessages cannot be initialized by the user. Therefore stan:Message can be made a record with those 2 fields. Remote method ack() will be moved to stan:Caller. 

- [**Service-related changes**](https://docs.google.com/document/d/1AS1BD0qPdP1E870GKowwvcsoFb8ij9aS78X3y6Zop-Y/edit?usp=sharing)

## Examples with the added changes

**Producing a message**
```ballerina
import ballerinax/stan;

public function main() returns error? {
    stan:Client producer = new;
    string message = "hello world";
    stan:Error? result = producer->publish(subject, message.toBytes());
}
```

**Subscribing and consuming messages**
```ballerina
import ballerina/lang.'string;
import ballerina/log;
import ballerinax/stan;

listener stan:Listener lis = new;

@ServiceConfig {
    subject: SERVICE_SUBJECT_NAME
}
service demo on lis {
    remote function onMessage(stan:Message message) {
        string|error messageContent = 'string:fromBytes(message.content);
        if (messageContent is string) {
            asyncConsumerMessage = <@untainted> messageContent;
            log:printInfo("The message received: " + messageContent);
        } else {
            log:printError("Error occurred while retrieving the message content.");
        }
    }
}
```

**Acknowledging messages**
```ballerina
import ballerinax/stan;

listener stan:Listener lis = new;

@ServiceConfig {
    subject: SERVICE_SUBJECT_NAME
}
service demo on lis {
    remote function onMessage(stan:Message message, stan:Caller caller) {
        checkpanic caller->ack();
    }
}
```