### PR TITLE
STAN package updates for Swan Lake alpha4

### DIFF
--- a/stan-ballerina/Package.md
+++ b/stan-ballerina/Package.md
@@ -15,7 +15,7 @@ NATS Streaming server.
 
 1. Connect to a server using the default URL
 ```ballerina
-stan:Client newClient = check new(nats:DEFAULT_URL);
+stan:Client newClient = check new(stan:DEFAULT_URL);
 ```
 
 2. Connect to a server using the URL
@@ -54,7 +54,7 @@ stan:Error? result = producer->publishMessage({ content: message, subject: "demo
 
 ```ballerina
 // Initializes the NATS Streaming listener.
-listener stan:Listener subscription = new(nats:DEFAULT_URL);
+listener stan:Listener subscription = new(stan:DEFAULT_URL);
 
 // Binds the consumer to listen to the messages published to the 'demo' subject.
 @stan:ServiceConfig {

--- a/stan-ballerina/Package.md
+++ b/stan-ballerina/Package.md
@@ -5,7 +5,6 @@ below functionalities.
 
 - Point to point communication (Queues)
 - Pub/Sub (Topics)
-- Request/Reply
 
 ### Basic Usage
 
@@ -14,14 +13,24 @@ below functionalities.
 First step is setting up the connection with the NATS Streaming server. The following ways can be used to connect to a
 NATS Streaming server.
 
-1. Connect to a server using the URL
+1. Connect to a server using the default URL
 ```ballerina
-stan:Client newClient = checkpanic new("nats://localhost:4222");
+stan:Client newClient = check new(nats:DEFAULT_URL);
 ```
 
-2. Connect to one or more servers with a custom configuration
+2. Connect to a server using the URL
 ```ballerina
-stan:Client newClient = checkpanic new({"nats://serverone:4222", "nats://servertwo:4222"},  config);
+stan:Client newClient = check new("nats://localhost:4222");
+```
+
+3. Connect to a server with a custom configuration
+```ballerina
+stan:StreamingConfiguration config = {
+  clusterId: "test-cluster",
+  ackTimeout: 30,
+  connectionTimeout: 5;
+};
+stan:Client newClient = check new("nats://localhost:4222",  config);
 ```
 
 #### Publishing messages
@@ -45,18 +54,16 @@ stan:Error? result = producer->publishMessage({ content: message, subject: "demo
 
 ```ballerina
 // Initializes the NATS Streaming listener.
-listener stan:Listener subscription = new;
+listener stan:Listener subscription = new(nats:DEFAULT_URL);
 
 // Binds the consumer to listen to the messages published to the 'demo' subject.
 @stan:ServiceConfig {
     subject: "demo"
 }
-service demo on subscription {
-
-    resource function onMessage(stan:Message msg, stan:Caller caller) {
+service stan:Service on subscription {
+    
+    remote function onMessage(stan:Message message, stan:Caller caller) {
     }
-
-
 }
 ```
 
@@ -66,7 +73,6 @@ For information on the operations, which you can perform with this package, see 
 
 For examples on the usage of the connector, see the following.
 * [Basic Streaming Publisher and Subscriber Example](https://ballerina.io/learn/by-example/nats-streaming-client.html)
-* [Streaming Publisher and Subscriber With Data Binding Example](https://ballerina.io/learn/by-example/nats-streaming-consumer-with-data-binding.html)
 * [Durable Subscriptions Example](https://ballerina.io/learn/by-example/nats-streaming-durable-subscriptions.html)
 * [Queue Groups Example](https://ballerina.io/learn/by-example/nats-streaming-queue-group.html)
 * [Historical Message Replay Example](https://ballerina.io/learn/by-example/nats-streaming-start-position.html)

--- a/stan-ballerina/caller.bal
+++ b/stan-ballerina/caller.bal
@@ -21,7 +21,7 @@ public client class Caller {
 
    # Acknowledges the NATS streaming server upon the receipt of the message.
    #
-   # + return - `()` or else a `nats:Error` upon failure to acknowledge the server
+   # + return - `()` or else a `stan:Error` upon failure to acknowledge the server
    isolated remote function ack() returns Error? {
        return externAck(self);
    }

--- a/stan-ballerina/client.bal
+++ b/stan-ballerina/client.bal
@@ -21,10 +21,10 @@ public client class Client {
 
     # Creates a new `stan:Client` instance.
     #
-    # + url - The NATS Broker URL
+    # + url - The NATS Broker URL. For a clustered use case, provide the URLs as a string array
     # + streamingConfig - The configuration related to the NATS streaming connectivity
-    public isolated function init(string url, *StreamingConfiguration connectionConfig) returns Error? {
-        return streamingProducerInit(self, url, connectionConfig);
+    public isolated function init(string|string[] url, *StreamingConfiguration connectionConfig) returns Error? {
+        return streamingClientInit(self, url, connectionConfig);
     }
 
     # Publishes data to a given subject.
@@ -50,8 +50,8 @@ public client class Client {
     }
 }
 
-isolated function streamingProducerInit(Client streamingClient, string urlString, *StreamingConfiguration streamingConfig)
-returns Error? = @java:Method {
+isolated function streamingClientInit(Client streamingClient, string|string[] urlString,
+*StreamingConfiguration streamingConfig) returns Error? = @java:Method {
     'class: "org.ballerinalang.nats.streaming.producer.Init"
 } external;
 

--- a/stan-ballerina/client.bal
+++ b/stan-ballerina/client.bal
@@ -21,9 +21,10 @@ public client class Client {
 
     # Creates a new `stan:Client` instance.
     #
+    # + url - The NATS Broker URL
     # + streamingConfig - The configuration related to the NATS streaming connectivity
-    public isolated function init(*StreamingConfiguration connectionConfig) returns Error? {
-        return streamingProducerInit(self, connectionConfig);
+    public isolated function init(string url, *StreamingConfiguration connectionConfig) returns Error? {
+        return streamingProducerInit(self, url, connectionConfig);
     }
 
     # Publishes data to a given subject.
@@ -49,7 +50,7 @@ public client class Client {
     }
 }
 
-isolated function streamingProducerInit(Client streamingClient, *StreamingConfiguration streamingConfig)
+isolated function streamingProducerInit(Client streamingClient, string urlString, *StreamingConfiguration streamingConfig)
 returns Error? = @java:Method {
     'class: "org.ballerinalang.nats.streaming.producer.Init"
 } external;

--- a/stan-ballerina/config.bal
+++ b/stan-ballerina/config.bal
@@ -21,7 +21,6 @@ public const string DEFAULT_URL = "nats://localhost:4222";
 
 # Configuration related to establishing a streaming connection.
 #
-# + url - The NATS Broker URL
 # + clientId - A unique identifier of the client
 # + clusterId - The unique identifier of the cluster configured in the NATS server
 # + ackTimeout - Timeout (in seconds) to wait for an acknowledgement
@@ -35,7 +34,6 @@ public const string DEFAULT_URL = "nats://localhost:4222";
 # + auth - Configurations related to authentication
 # + secureSocket - Configurations related to SSL/TLS
 public type StreamingConfiguration record {|
-  string url = DEFAULT_URL;
   string clientId?;
   string clusterId = "test-cluster";
   decimal ackTimeout = 30;

--- a/stan-ballerina/error.bal
+++ b/stan-ballerina/error.bal
@@ -21,7 +21,7 @@ public type Error distinct error;
 #
 # + message - The error message
 # + err - The `error` instance
-# + return - Prepared `nats:Error` instance
+# + return - Prepared `stan:Error` instance
 isolated function prepareError(string message, error? err = ()) returns Error {
     if (err is error) {
         return error Error(message, err);

--- a/stan-ballerina/listener.bal
+++ b/stan-ballerina/listener.bal
@@ -27,13 +27,14 @@ public class Listener {
 
     # Creates a new Streaming Listener.
     #
+    # + url - The NATS Broker URL
     # + streamingConfig - The configuration related to the NATS streaming connectivity
-    public isolated function init(*StreamingConfiguration streamingConfig) returns Error? {
-        self.url = streamingConfig.url;
+    public isolated function init(string url, *StreamingConfiguration streamingConfig) returns Error? {
+        self.url = url;
         self.clusterId = streamingConfig.clusterId;
         self.clientId = streamingConfig?.clientId;
         self.streamingConfig = streamingConfig;
-        return streamingListenerInit(self, streamingConfig);
+        return streamingListenerInit(self, url, streamingConfig);
     }
 
     # Binds a service to the `nats:Listener`.
@@ -79,7 +80,7 @@ public class Listener {
     }
 }
 
-isolated function streamingListenerInit(Listener lis, *StreamingConfiguration streamingConfig)
+isolated function streamingListenerInit(Listener lis, string urlString, *StreamingConfiguration streamingConfig)
 returns Error? = @java:Method {
     'class: "org.ballerinalang.nats.streaming.consumer.Init"
 } external;

--- a/stan-ballerina/listener.bal
+++ b/stan-ballerina/listener.bal
@@ -37,40 +37,40 @@ public class Listener {
         return streamingListenerInit(self, url, streamingConfig);
     }
 
-    # Binds a service to the `nats:Listener`.
+    # Binds a service to the `stan:Listener`.
     #
     # + s - Type descriptor of the service
     # + name - Name of the service
-    # + return - `()` or else a `nats:Error` upon failure to register the listener
+    # + return - `()` or else a `stan:Error` upon failure to register the listener
     public isolated function attach(Service s, string|string[]? name = ()) returns error? {
         streamingAttach(self, s, self.url);
     }
 
-    # Stops consuming messages and detaches the service from the `nats:Listener`.
+    # Stops consuming messages and detaches the service from the `stan:Listener`.
     #
     # + s - Type descriptor of the service
-    # + return - `()` or else a `nats:Error` upon failure to detach the service
+    # + return - `()` or else a `stan:Error` upon failure to detach the service
     public isolated function detach(Service s) returns error? {
         streamingDetach(self, s);
     }
 
-    # Starts the `nats:Listener`.
+    # Starts the `stan:Listener`.
     #
-    # + return - `()` or else a `nats:Error` upon failure to start the listener
+    # + return - `()` or else a `stan:Error` upon failure to start the listener
     public isolated function 'start() returns error? {
          streamingSubscribe(self);
     }
 
-    # Stops the `nats:Listener` gracefully.
+    # Stops the `stan:Listener` gracefully.
     #
-    # + return - `()` or else a `nats:Error` upon failure to stop the listener
+    # + return - `()` or else a `stan:Error` upon failure to stop the listener
     public isolated function gracefulStop() returns error? {
         return ();
     }
 
-    # Stops the `nats:Listener` forcefully.
+    # Stops the `stan:Listener` forcefully.
     #
-    # + return - `()` or else a `nats:Error` upon failure to stop the listener
+    # + return - `()` or else a `stan:Error` upon failure to stop the listener
     public isolated function immediateStop() returns error? {
         return self.close();
     }

--- a/stan-ballerina/listener.bal
+++ b/stan-ballerina/listener.bal
@@ -20,16 +20,16 @@ import ballerina/jballerina.java;
 # receive messages of the corresponding subscription.
 public class Listener {
 
-    private string url;
+    private string|string[] url;
     private string clusterId;
     private string? clientId;
     private StreamingConfiguration streamingConfig;
 
     # Creates a new Streaming Listener.
     #
-    # + url - The NATS Broker URL
+    # + url - The NATS Broker URL. For a clustered use case, provide the URLs as a string array
     # + streamingConfig - The configuration related to the NATS streaming connectivity
-    public isolated function init(string url, *StreamingConfiguration streamingConfig) returns Error? {
+    public isolated function init(string|string[] url, *StreamingConfiguration streamingConfig) returns Error? {
         self.url = url;
         self.clusterId = streamingConfig.clusterId;
         self.clientId = streamingConfig?.clientId;
@@ -80,8 +80,8 @@ public class Listener {
     }
 }
 
-isolated function streamingListenerInit(Listener lis, string urlString, *StreamingConfiguration streamingConfig)
-returns Error? = @java:Method {
+isolated function streamingListenerInit(Listener lis, string|string[] urlString,
+*StreamingConfiguration streamingConfig) returns Error? = @java:Method {
     'class: "org.ballerinalang.nats.streaming.consumer.Init"
 } external;
 
@@ -90,7 +90,7 @@ isolated function streamingSubscribe(Listener streamingClient) =
     'class: "org.ballerinalang.nats.streaming.consumer.Subscribe"
 } external;
 
-isolated function streamingAttach(Listener lis, Service serviceType, string conn, string|string[]? name = ()) =
+isolated function streamingAttach(Listener lis, Service serviceType, string|string[] url, string|string[]? name = ()) =
 @java:Method {
     'class: "org.ballerinalang.nats.streaming.consumer.Attach"
 } external;

--- a/stan-ballerina/tests/nats_streaming_server_tests.bal
+++ b/stan-ballerina/tests/nats_streaming_server_tests.bal
@@ -26,7 +26,7 @@ string receivedConsumerMessage = "";
 
 @test:BeforeSuite
 function setup() {
-    Client newClient = checkpanic new;
+    Client newClient = checkpanic new(DEFAULT_URL);
     clientObj = newClient;
 }
 
@@ -63,8 +63,8 @@ public function testProducer() {
 }
 public function testConsumerService() {
     string message = "Testing Consumer Service";
-    Listener sub = checkpanic new;
-    Client newClient = checkpanic new;
+    Listener sub = checkpanic new(DEFAULT_URL);
+    Client newClient = checkpanic new(DEFAULT_URL);
     checkpanic sub.attach(consumerService);
     checkpanic sub.'start();
     string id = checkpanic newClient->publishMessage({ content: message.toBytes(), subject: SERVICE_SUBJECT_NAME});

--- a/stan-native/src/main/java/org/ballerinalang/nats/Utils.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/Utils.java
@@ -20,6 +20,7 @@ package org.ballerinalang.nats;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.Module;
+import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.Type;
@@ -79,5 +80,17 @@ public class Utils {
 
     public static String getCommaSeparatedUrl(BObject connectionObject) {
         return String.join(", ", connectionObject.getArrayValue(Constants.URL).getStringArray());
+    }
+
+    // Used for observability, not for connection establishing
+    public static String getCommaSeparatedUrl(Object urlString) {
+        if (TypeUtils.getType(urlString).getTag() == TypeTags.ARRAY_TAG) {
+            // if string[]
+            String[] serverUrls = ((BArray) urlString).getStringArray();
+            return String.join(", ", serverUrls);
+        } else {
+            // if string
+            return ((BString) urlString).getValue();
+        }
     }
 }

--- a/stan-native/src/main/java/org/ballerinalang/nats/connection/NatsStreamingConnection.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/connection/NatsStreamingConnection.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class NatsStreamingConnection {
 
-    public static StreamingConnection createConnection(BObject streamingClientObject, String url,
+    public static StreamingConnection createConnection(BObject streamingClientObject, Object url,
                                                        String clusterId, Object clientIdNillable,
                                                        BMap<BString, Object> streamingConfig)
             throws IOException, InterruptedException, UnrecoverableKeyException, CertificateException,

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/Attach.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/Attach.java
@@ -44,7 +44,7 @@ public class Attach {
 
 
     public static void streamingAttach(Environment environment, BObject streamingListener, BObject service,
-                                       BString streamingConnectionUrl, Object serviceName) {
+                                       Object streamingConnectionUrl, Object serviceName) {
         String subject;
         BMap<BString, Object> annotation = (BMap<BString, Object>) service.getType()
                 .getAnnotation(StringUtils.fromString(Utils.getModule().getOrg() + ORG_NAME_SEPARATOR +
@@ -64,7 +64,7 @@ public class Attach {
                         .getNativeData(STREAMING_DISPATCHER_LIST);
         boolean manualAck = !getAckMode(service);
         serviceListenerMap.put(service, new StreamingListener(service, manualAck, environment.getRuntime(),
-                                                              streamingConnectionUrl.getValue(), subject));
+                                                              streamingConnectionUrl, subject));
     }
 
     private static boolean getAckMode(BObject service) {

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/Init.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/Init.java
@@ -43,13 +43,13 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class Init {
 
-    public static Object streamingListenerInit(BObject streamingListener, BString url,
+    public static Object streamingListenerInit(BObject streamingListener, Object url,
                                                BMap<BString, Object> streamingConfig) {
         StreamingConnection streamingConnection;
         BString clusterId = streamingConfig.getStringValue(Constants.CLUSTER_ID);
         Object clientIdNillable = streamingConfig.get(Constants.CLIENT_ID);
         try {
-            streamingConnection = NatsStreamingConnection.createConnection(streamingListener, url.getValue(),
+            streamingConnection = NatsStreamingConnection.createConnection(streamingListener, url,
                                                                            clusterId.getValue(), clientIdNillable,
                                                                            streamingConfig);
         } catch (IOException e) {

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/Init.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/Init.java
@@ -43,14 +43,13 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class Init {
 
-    public static Object streamingListenerInit(BObject streamingListener, BMap<BString, Object> streamingConfig) {
+    public static Object streamingListenerInit(BObject streamingListener, BString url,
+                                               BMap<BString, Object> streamingConfig) {
         StreamingConnection streamingConnection;
-        BString connectionObject = streamingConfig.getStringValue(Constants.URL);
         BString clusterId = streamingConfig.getStringValue(Constants.CLUSTER_ID);
         Object clientIdNillable = streamingConfig.get(Constants.CLIENT_ID);
         try {
-            streamingConnection = NatsStreamingConnection.createConnection(streamingListener,
-                                                                           connectionObject.getValue(),
+            streamingConnection = NatsStreamingConnection.createConnection(streamingListener, url.getValue(),
                                                                            clusterId.getValue(), clientIdNillable,
                                                                            streamingConfig);
         } catch (IOException e) {

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/StreamingListener.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/StreamingListener.java
@@ -46,6 +46,7 @@ import static org.ballerinalang.nats.Constants.NATS_STREAMING_MESSAGE_OBJ_NAME;
 import static org.ballerinalang.nats.Constants.ON_ERROR_RESOURCE;
 import static org.ballerinalang.nats.Constants.ON_MESSAGE_RESOURCE;
 import static org.ballerinalang.nats.Utils.getAttachedFunctionType;
+import static org.ballerinalang.nats.Utils.getCommaSeparatedUrl;
 
 /**
  * {@link MessageHandler} implementation to listen to Messages of the subscribed subject from NATS streaming server.
@@ -54,16 +55,18 @@ public class StreamingListener implements MessageHandler {
     private BObject service;
     private Runtime runtime;
     private String connectedUrl;
+    private Object connectedUrlObj;
     private boolean manualAck;
     private String subject;
 
     public StreamingListener(BObject service, boolean manualAck, Runtime runtime,
-                             String connectedUrl, String subject) {
+                             Object connectedUrl, String subject) {
         this.service = service;
         this.runtime = runtime;
         this.manualAck = manualAck;
-        this.connectedUrl = connectedUrl;
+        this.connectedUrlObj = connectedUrl;
         this.subject = subject;
+        this.connectedUrl = getCommaSeparatedUrl(connectedUrlObj);
     }
 
     /**

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/producer/Init.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/producer/Init.java
@@ -42,13 +42,13 @@ import java.security.cert.CertificateException;
  */
 public class Init {
 
-    public static Object streamingProducerInit(BObject streamingClientObject, BString url,
+    public static Object streamingClientInit(BObject streamingClientObject, Object url,
                                                BMap<BString, Object> streamingConfig) {
         BString clusterId = streamingConfig.getStringValue(Constants.CLUSTER_ID);
         Object clientIdNillable = streamingConfig.get(Constants.CLIENT_ID);
         StreamingConnection connection;
         try {
-            connection = NatsStreamingConnection.createConnection(streamingClientObject, url.getValue(),
+            connection = NatsStreamingConnection.createConnection(streamingClientObject, url,
                                                                   clusterId.getValue(), clientIdNillable,
                                                                   streamingConfig);
         } catch (IOException e) {

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/producer/Init.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/producer/Init.java
@@ -42,8 +42,8 @@ import java.security.cert.CertificateException;
  */
 public class Init {
 
-    public static Object streamingProducerInit(BObject streamingClientObject, BMap<BString, Object> streamingConfig) {
-        BString url = streamingConfig.getStringValue(Constants.URL);
+    public static Object streamingProducerInit(BObject streamingClientObject, BString url,
+                                               BMap<BString, Object> streamingConfig) {
         BString clusterId = streamingConfig.getStringValue(Constants.CLUSTER_ID);
         Object clientIdNillable = streamingConfig.get(Constants.CLIENT_ID);
         StreamingConnection connection;


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1176 

## Changes:
1. Client and listener init change **[Breaking]** 
```ballerina
// old syntax
stan:Client stanClient = check new;
stan:Client stanClient = check new(url = "nats://localhost:4222");

// new syntax - URL is not defaultable, it is mandatory
stan:Client stanClient = check new(stan:DEFAULT_URL);
stan:Client stanClient = check new("nats://localhost:4222");

// in both can pass remaining config values as named args
```