### PR TITLE
Add STAN compiler plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ allprojects {
         }
 
         maven {
+            url = 'https://mvnrepository.com/artifact/org.testng/testng'
+        }
+
+        maven {
             url = 'https://maven.wso2.org/nexus/content/groups/wso2-public/'
         }
 
@@ -103,8 +107,14 @@ subprojects {
 
     configurations {
         ballerinaStdLibs
+        jbalTools
     }
     dependencies {
+        /* JBallerina Tools */
+        jbalTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
+            transitive = false
+        }
+
         /* Standard libraries */
         ballerinaStdLibs "org.ballerinalang:log-ballerina:${stdlibLogVersion}"
         ballerinaStdLibs "org.ballerinalang:crypto-ballerina:${stdlibCryptoVersion}"

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ This file contains all the notable changes done to the Ballerina STAN package th
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0-alpha8] - 2021-04-22
+
+### Added
+
+- [Add compiler plugin validations for STAN services.](https://github.com/ballerina-platform/ballerina-standard-library/issues/1114)
+
 ## [1.1.0-alpha6] - 2021-04-02
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ version=1.1.0-alpha8-SNAPSHOT
 ballerinaLangVersion=2.0.0-alpha7-20210403-234900-bdd55df1
 
 puppycrawlCheckstyleVersion=8.18
+testngVersion=7.4.0
 
 stdlibCryptoVersion=1.1.0-alpha7
 stdlibLogVersion=1.1.0-alpha7

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,8 +13,7 @@ plugins {
 
 rootProject.name = 'stan'
 include(':build-config:checkstyle')
-include ':stan-native', ':stan-ballerina'
-include 'stan-native'
+include ':stan-ballerina', 'stan-native', 'stan-compiler-plugin', 'stan-compiler-plugin-tests'
 
 gradleEnterprise {
     buildScan {

--- a/stan-ballerina/CompilerPlugin.toml
+++ b/stan-ballerina/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "stan-compiler-plugin"
+class = "io.ballerina.stdlib.stan.plugin.StanCompilerPlugin"
+
+[[dependency]]
+path = "../stan-compiler-plugin/build/libs/stan-compiler-plugin-@project.version@.jar"

--- a/stan-ballerina/build.gradle
+++ b/stan-ballerina/build.gradle
@@ -25,12 +25,14 @@ def platform = "java11"
 def tomlVersion = project.version.replace("-SNAPSHOT", "")
 def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
 def ballerinaDependencyFile = new File("$project.projectDir/Dependencies.toml")
+def ballerinaCompilerPluginFile = new File("$project.projectDir/CompilerPlugin.toml")
 def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
 def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
 def artifactLibParent = file("$project.projectDir/build/lib_parent/")
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def originalConfig = ballerinaConfigFile.text
 def originalDependencies = ballerinaDependencyFile.text
+def originalCompilerPlugin = ballerinaCompilerPluginFile.text
 def distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 
 configurations {
@@ -39,10 +41,7 @@ configurations {
 }
 
 dependencies {
-    jbalTools("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
-        transitive = false
-    }
-    compile project(":${packageName}-native")
+    implementation project(":${packageName}-native")
     externalJars (group: 'io.nats', name: 'java-nats-streaming', version: "${natsStreamingVersion}") {
         transitive = false
     }
@@ -116,6 +115,9 @@ task updateTomlVersions {
         def newDependencyConfig = ballerinaDependencyFile.text.replace("@stdlib.log.version@", stdlibDependentLogVersion)
         newDependencyConfig = newDependencyConfig.replace("@stdlib.crypto.version@", stdlibDependentCryptoVersion)
         ballerinaDependencyFile.text = newDependencyConfig
+
+        def newPluginConfig = ballerinaCompilerPluginFile.text.replace("@project.version@", project.version)
+        ballerinaCompilerPluginFile.text = newPluginConfig
     }
 }
 
@@ -123,6 +125,7 @@ task revertTomlFile {
     doLast {
         ballerinaConfigFile.text = originalConfig
         ballerinaDependencyFile.text = originalDependencies
+        ballerinaCompilerPluginFile.text = originalCompilerPlugin
     }
 }
 
@@ -339,6 +342,7 @@ updateTomlVersions.dependsOn copyStdlibs
 
 ballerinaTest.dependsOn startNatsServer
 ballerinaTest.dependsOn ":${packageName}-native:build"
+ballerinaTest.dependsOn ":${packageName}-compiler-plugin:build"
 ballerinaTest.dependsOn updateTomlVersions
 ballerinaTest.dependsOn initializeVariables
 ballerinaTest.finalizedBy stopNatsServer
@@ -347,6 +351,7 @@ test.dependsOn ballerinaTest
 
 ballerinaBuild.dependsOn updateTomlVersions
 ballerinaBuild.dependsOn ":${packageName}-native:build"
+ballerinaTest.dependsOn ":${packageName}-compiler-plugin:build"
 ballerinaBuild.dependsOn initializeVariables
 ballerinaBuild.dependsOn startNatsServer
 ballerinaBuild.finalizedBy revertTomlFile
@@ -358,5 +363,6 @@ ballerinaPublish.dependsOn ballerinaBuild
 ballerinaPublish.dependsOn updateTomlVersions
 ballerinaPublish.dependsOn initializeVariables
 ballerinaPublish.dependsOn ":${packageName}-native:build"
+ballerinaTest.dependsOn ":${packageName}-compiler-plugin:build"
 ballerinaPublish.finalizedBy revertTomlFile
 publish.dependsOn ballerinaPublish

--- a/stan-compiler-plugin-tests/build.gradle
+++ b/stan-compiler-plugin-tests/build.gradle
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - STAN Compiler Plugin Tests'
+
+def ballerinaModulePath = "${project.rootDir}/stan-ballerina/"
+def ballerinaDistPath = "${ballerinaModulePath}/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+def ballerinaDist = "${buildDir}/target/ballerina-distribution"
+
+dependencies {
+    checkstyle project(':build-config:checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
+    testImplementation project(":stan-compiler-plugin")
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
+}
+
+tasks.withType(Checkstyle) {
+    exclude '**/module-info.java'
+}
+
+checkstyle {
+    toolVersion "${project.puppycrawlCheckstyleVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleTest.dependsOn(":build-config:checkstyle:downloadMultipleFiles")
+
+spotbugsTest {
+    effort "max"
+    reportLevel "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reports {
+        html.enabled true
+        text.enabled = true
+    }
+    def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
+    if(excludeFile.exists()) {
+        excludeFilter = excludeFile
+    }
+}
+
+spotbugsMain {
+    enabled false
+}
+
+checkstyleMain {
+    enabled false
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}
+
+task copyDistribution(type: Copy) {
+    from ballerinaDistPath
+    into ballerinaDist
+}
+
+task copyPackageBala {
+    doLast {
+        copy {
+            from "${ballerinaModulePath}/build/cache_parent"
+            into "${ballerinaDist}/repo"
+            copy {
+                into("bala/ballerina") {
+                    from "bala/ballerina"
+                }
+            }
+            copy {
+                into("cache/ballerina/") {
+                    from "cache/ballerina"
+                }
+            }
+        }
+    }
+}
+
+test {
+    useTestNG()
+}
+
+copyDistribution.dependsOn ":stan-ballerina:build"
+copyPackageBala.dependsOn copyDistribution
+test.dependsOn copyPackageBala

--- a/stan-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/stan/plugin/StanCompilerPluginTest.java
+++ b/stan-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/stan/plugin/StanCompilerPluginTest.java
@@ -227,6 +227,16 @@ public class StanCompilerPluginTest {
         assertDiagnostic(diagnostic, CompilationErrors.INVALID_MULTIPLE_LISTENERS);
     }
 
+    @Test
+    public void testInvalidService14() {
+        Package currentPackage = loadPackage("invalid_service_14");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.INVALID_FUNCTION);
+    }
+
     private Package loadPackage(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);

--- a/stan-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/stan/plugin/StanCompilerPluginTest.java
+++ b/stan-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/stan/plugin/StanCompilerPluginTest.java
@@ -201,6 +201,16 @@ public class StanCompilerPluginTest {
         }
     }
 
+    @Test
+    public void testInvalidService13() {
+        Package currentPackage = loadPackage("invalid_service_13");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.INVALID_MULTIPLE_LISTENERS);
+    }
+
     private Package loadPackage(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);

--- a/stan-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/stan/plugin/StanCompilerPluginTest.java
+++ b/stan-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/stan/plugin/StanCompilerPluginTest.java
@@ -67,6 +67,22 @@ public class StanCompilerPluginTest {
     }
 
     @Test
+    public void testValidService4() {
+        Package currentPackage = loadPackage("valid_service_4");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
+    public void testValidService5() {
+        Package currentPackage = loadPackage("valid_service_5");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
     public void testInvalidService1() {
         Package currentPackage = loadPackage("invalid_service_1");
         PackageCompilation compilation = currentPackage.getCompilation();

--- a/stan-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/stan/plugin/StanCompilerPluginTest.java
+++ b/stan-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/stan/plugin/StanCompilerPluginTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.stan.plugin;
+
+import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.stdlib.stan.plugin.PluginConstants.CompilationErrors;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests for STAN package compiler plugin.
+ */
+public class StanCompilerPluginTest {
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "ballerina_sources")
+            .toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get("build", "target", "ballerina-distribution")
+            .toAbsolutePath();
+
+    @Test
+    public void testValidService1() {
+        Package currentPackage = loadPackage("valid_service_1");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
+    public void testValidService2() {
+        Package currentPackage = loadPackage("valid_service_2");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
+    public void testValidService3() {
+        Package currentPackage = loadPackage("valid_service_3");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
+    public void testInvalidService1() {
+        Package currentPackage = loadPackage("invalid_service_1");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.NO_ON_MESSAGE);
+    }
+
+    @Test
+    public void testInvalidService2() {
+        Package currentPackage = loadPackage("invalid_service_2");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.INVALID_REMOTE_FUNCTION);
+    }
+
+    @Test
+    public void testInvalidService3() {
+        Package currentPackage = loadPackage("invalid_service_3");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 2);
+        Object[] diagnostics = diagnosticResult.diagnostics().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, CompilationErrors.FUNCTION_SHOULD_BE_REMOTE);
+        }
+    }
+
+    @Test
+    public void testInvalidService4() {
+        Package currentPackage = loadPackage("invalid_service_4");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.MUST_HAVE_MESSAGE);
+    }
+
+    @Test
+    public void testInvalidService5() {
+        Package currentPackage = loadPackage("invalid_service_5");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.ONLY_PARAMS_ALLOWED);
+    }
+
+    @Test
+    public void testInvalidService6() {
+        Package currentPackage = loadPackage("invalid_service_6");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 2);
+        Object[] diagnostics = diagnosticResult.diagnostics().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE);
+        }
+    }
+
+    @Test
+    public void testInvalidService7() {
+        Package currentPackage = loadPackage("invalid_service_7");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL);
+    }
+
+    @Test
+    public void testInvalidService8() {
+        Package currentPackage = loadPackage("invalid_service_8");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 2);
+        Object[] diagnostics = diagnosticResult.diagnostics().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE);
+        }
+    }
+
+    @Test
+    public void testInvalidService9() {
+        Package currentPackage = loadPackage("invalid_service_9");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.MUST_HAVE_MESSAGE_AND_ERROR);
+    }
+
+    @Test
+    public void testInvalidService10() {
+        Package currentPackage = loadPackage("invalid_service_10");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.ONLY_PARAMS_ALLOWED_ON_ERROR);
+    }
+
+    @Test
+    public void testInvalidService11() {
+        Package currentPackage = loadPackage("invalid_service_11");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 2);
+        Object[] diagnostics = diagnosticResult.diagnostics().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, CompilationErrors.INVALID_FUNCTION_PARAM_ERROR);
+        }
+    }
+
+    @Test
+    public void testInvalidService12() {
+        Package currentPackage = loadPackage("invalid_service_12");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 2);
+        Object[] diagnostics = diagnosticResult.diagnostics().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, CompilationErrors.INVALID_FUNCTION_PARAM_CALLER);
+        }
+    }
+
+    private Package loadPackage(String path) {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
+        BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);
+        return project.currentPackage();
+    }
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+
+    private void assertDiagnostic(Diagnostic diagnostic, CompilationErrors error) {
+        Assert.assertEquals(diagnostic.diagnosticInfo().code(), error.getErrorCode());
+        Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                error.getError());
+    }
+}

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_1/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_1"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_1/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_1/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
-    }
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_10"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+    remote function onError(stan:Message message, stan:Error err, string data) {
     }
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_11/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_11/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_11"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_11/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_11/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+    remote function onError(stan:Message message, string err) {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+    remote function onError(stan:Message message, stan:Client err) {
     }
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_12/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_12/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_12"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_12/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_12/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message, string caller) {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message, stan:Client caller) {
     }
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_13/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_13/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_13"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_13/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_13/service.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/stan;
+
+listener stan:Listener lis1 = new(stan:DEFAULT_URL);
+listener stan:Listener lis2 = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis1, lis2 {
+    remote function onMessage(stan:Message message) {
+    }
+}

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_14/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_14/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_14"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_14/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_14/service.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/stan;
+
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+
+    resource function get greeting() returns string {
+        return "Hello";
+    }
+}

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_2"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
     }
+
+    remote function someFunction() {}
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_3"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    function onMessage(stan:Message message) {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+
+    function onError(stan:Message message, stan:Error err) {
     }
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_4"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+
+    remote function onMessage() {
     }
 }
+

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_5/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_5"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_5/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_5/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+
+    remote function onMessage(stan:Message msg, stan:Caller caller, string data) {
     }
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_6/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_6/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_6"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_6/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_6/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+
+    remote function onMessage(stan:Client clientObj) {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+
+    remote function onMessage(string msg) {
     }
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_7/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_7/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_7"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_7/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_7/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) returns string {
+        return "Hello";
     }
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_8"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,29 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+
+    remote function onError(string message, stan:Error err) {
     }
 }
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message, stan:Caller caller) {
+    }
+
+    remote function onError(stan:Client clientObj, stan:Error err) {
+    }
+}
+

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_9/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_9/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "invalid_service_9"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_9/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_9/service.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,18 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the STAN module related errors.
-public type Error distinct error;
+import ballerinax/stan;
 
-# Prepare the `error` as a `Error`.
-#
-# + message - The error message
-# + err - The `error` instance
-# + return - Prepared `stan:Error` instance
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    } else {
-        return error Error(message);
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+    remote function onError(stan:Message message) {
     }
 }

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/testng.xml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/testng.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="BallerinaGraphqlCompilerPluginTests">
+    <test name="UnitTests">
+        <classes>
+            <class name="io.ballerina.stdlib.stan.plugin.StanCompilerPluginTest"/>
+        </classes>
+    </test>
+</suite>

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "valid_service_1"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/service.bal
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/stan;
+
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message, stan:Caller caller) {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+
+    remote function onError(stan:Message message, stan:Error err) {
+    }
+}

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "valid_service_2"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/service.bal
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/stan;
+
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) returns error? {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message, stan:Caller caller) returns error? {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) returns stan:Error? {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) returns ()|error {
+    }
+}

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_3/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "valid_service_3"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_3/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_3/service.bal
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/stan;
+
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+    remote function onError(stan:Message message, stan:Error err) returns ()|error {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message, stan:Caller caller) {
+    }
+
+    remote function onError(stan:Message message, stan:Error err) returns stan:Error? {
+    }
+}
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(stan:Message message) {
+    }
+
+    remote function onError(stan:Message message, stan:Error err) returns error? {
+    }
+}

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_4/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_4/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "valid_service_4"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_4/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_4/service.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/stan as foo;
+
+listener foo:Listener lis = new(foo:DEFAULT_URL);
+
+@foo:ServiceConfig {
+    subject: "demo"
+}
+service foo:Service on lis {
+    remote function onMessage(foo:Message message) {
+    }
+}
+

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/Ballerina.toml
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "stan_test"
+name = "valid_service_5"
+version = "0.1.0"

--- a/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/service.bal
+++ b/stan-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/service.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/stan;
+
+listener stan:Listener lis = new(stan:DEFAULT_URL);
+type Foo stan:Message;
+
+@stan:ServiceConfig {
+    subject: "demo"
+}
+service stan:Service on lis {
+    remote function onMessage(Foo message) {
+    }
+}

--- a/stan-compiler-plugin/build.gradle
+++ b/stan-compiler-plugin/build.gradle
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - STAN Compiler Plugin'
+
+dependencies {
+    checkstyle project(':build-config:checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+}
+
+checkstyle {
+    toolVersion '7.8.2'
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+def excludePattern = '**/module-info.java'
+tasks.withType(Checkstyle) {
+    exclude excludePattern
+}
+
+checkstyleMain.dependsOn(":build-config:checkstyle:downloadMultipleFiles")
+
+spotbugsMain {
+    effort "max"
+    reportLevel "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reports {
+        html.enabled true
+        text.enabled = true
+    }
+    def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
+    if(excludeFile.exists()) {
+        excludeFilter = excludeFile
+    }
+}
+
+spotbugsTest {
+    enabled = false
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginConstants.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginConstants.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.stan.plugin;
+
+/**
+ * STAN compiler plugin constants.
+ */
+public class PluginConstants {
+    // compiler plugin constants
+    public static final String PACKAGE_PREFIX = "stan";
+    public static final String REMOTE_QUALIFIER = "REMOTE";
+    public static final String ON_MESSAGE_FUNC = "onMessage";
+    public static final String ON_ERROR_FUNC = "onError";
+
+    // parameters
+    public static final String MESSAGE = "Message";
+    public static final String CALLER = "Caller";
+    public static final String ERROR_PARAM = "Error";
+
+    // return types error or nil
+    public static final String ERROR = "error";
+    public static final String STAN_ERROR = PACKAGE_PREFIX + ":" + ERROR_PARAM;
+    public static final String NIL = "?";
+    public static final String ERROR_OR_NIL = ERROR + NIL;
+    public static final String NIL_OR_ERROR = "()|" + ERROR;
+    public static final String STAN_ERROR_OR_NIL = STAN_ERROR + NIL;
+    public static final String NIL_OR_STAN_ERROR = "()|" + STAN_ERROR;
+
+    /**
+     * Compilation errors.
+     */
+    enum CompilationErrors {
+        NO_ON_MESSAGE("Service must have remote function onMessage.",
+                "STAN_101"),
+        INVALID_REMOTE_FUNCTION("Invalid remote function.", "STAN_102"),
+        FUNCTION_SHOULD_BE_REMOTE("Function must have the remote qualifier.", "STAN_103"),
+        MUST_HAVE_MESSAGE("Must have the function parameter stan:Message.", "STAN_104"),
+        MUST_HAVE_MESSAGE_AND_ERROR("Must have the function parameters stan:Message and stan:Error.",
+                "STAN_105"),
+        INVALID_FUNCTION_PARAM("Invalid function parameter.", "STAN_106"),
+        INVALID_FUNCTION_PARAM_MESSAGE("Invalid function parameter. Only stan:Message is allowed.",
+                "STAN_107"),
+        INVALID_FUNCTION_PARAM_ERROR("Invalid function parameter. Only stan:Error is allowed.",
+                "STAN_108"),
+        INVALID_FUNCTION_PARAM_CALLER("Invalid function parameter. Only stan:Caller is allowed.",
+                "STAN_109"),
+        ONLY_PARAMS_ALLOWED("Invalid function parameter count. Only stan:Message and stan:Caller are allowed.",
+                "STAN_110"),
+        ONLY_PARAMS_ALLOWED_ON_ERROR("Invalid function parameter count. Only stan:Message and stan:Error are allowed.",
+                "STAN_111"),
+        INVALID_RETURN_TYPE_ERROR_OR_NIL("Invalid return type. Only error? or stan:Error? is allowed.",
+                "STAN_112");
+
+        private final String error;
+        private final String errorCode;
+
+        CompilationErrors(String error, String errorCode) {
+            this.error = error;
+            this.errorCode = errorCode;
+        }
+
+        String getError() {
+            return error;
+        }
+
+        String getErrorCode() {
+            return errorCode;
+        }
+    }
+
+    private PluginConstants() {
+    }
+}

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginConstants.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginConstants.java
@@ -24,13 +24,14 @@ package io.ballerina.stdlib.stan.plugin;
 public class PluginConstants {
     // compiler plugin constants
     public static final String PACKAGE_PREFIX = "stan";
-    public static final String REMOTE_QUALIFIER = "REMOTE";
     public static final String ON_MESSAGE_FUNC = "onMessage";
     public static final String ON_ERROR_FUNC = "onError";
     public static final String PACKAGE_ORG = "ballerinax";
 
     // parameters
     public static final String MESSAGE = "Message";
+    public static final String CONTENT_FIELD = "content";
+    public static final String SUBJECT_FIELD = "subject";
     public static final String CALLER = "Caller";
     public static final String ERROR_PARAM = "Error";
 
@@ -47,23 +48,23 @@ public class PluginConstants {
      * Compilation errors.
      */
     enum CompilationErrors {
-        NO_ON_MESSAGE("Service must have remote function onMessage.",
+        NO_ON_MESSAGE("Service must have remote method onMessage.",
                 "STAN_101"),
-        INVALID_REMOTE_FUNCTION("Invalid remote function.", "STAN_102"),
-        FUNCTION_SHOULD_BE_REMOTE("Function must have the remote qualifier.", "STAN_103"),
-        MUST_HAVE_MESSAGE("Must have the function parameter stan:Message.", "STAN_104"),
-        MUST_HAVE_MESSAGE_AND_ERROR("Must have the function parameters stan:Message and stan:Error.",
+        INVALID_REMOTE_FUNCTION("Invalid remote method.", "STAN_102"),
+        FUNCTION_SHOULD_BE_REMOTE("Method must have the remote qualifier.", "STAN_103"),
+        MUST_HAVE_MESSAGE("Must have the method parameter stan:Message.", "STAN_104"),
+        MUST_HAVE_MESSAGE_AND_ERROR("Must have the method parameters stan:Message and stan:Error.",
                 "STAN_105"),
-        INVALID_FUNCTION_PARAM("Invalid function parameter.", "STAN_106"),
-        INVALID_FUNCTION_PARAM_MESSAGE("Invalid function parameter. Only stan:Message is allowed.",
+        INVALID_FUNCTION_PARAM("Invalid method parameter.", "STAN_106"),
+        INVALID_FUNCTION_PARAM_MESSAGE("Invalid method parameter. Only stan:Message is allowed.",
                 "STAN_107"),
-        INVALID_FUNCTION_PARAM_ERROR("Invalid function parameter. Only stan:Error is allowed.",
+        INVALID_FUNCTION_PARAM_ERROR("Invalid method parameter. Only stan:Error is allowed.",
                 "STAN_108"),
-        INVALID_FUNCTION_PARAM_CALLER("Invalid function parameter. Only stan:Caller is allowed.",
+        INVALID_FUNCTION_PARAM_CALLER("Invalid method parameter. Only stan:Caller is allowed.",
                 "STAN_109"),
-        ONLY_PARAMS_ALLOWED("Invalid function parameter count. Only stan:Message and stan:Caller are allowed.",
+        ONLY_PARAMS_ALLOWED("Invalid method parameter count. Only stan:Message and stan:Caller are allowed.",
                 "STAN_110"),
-        ONLY_PARAMS_ALLOWED_ON_ERROR("Invalid function parameter count. Only stan:Message and stan:Error are allowed.",
+        ONLY_PARAMS_ALLOWED_ON_ERROR("Invalid method parameter count. Only stan:Message and stan:Error are allowed.",
                 "STAN_111"),
         INVALID_RETURN_TYPE_ERROR_OR_NIL("Invalid return type. Only error? or stan:Error? is allowed.",
                 "STAN_112"),
@@ -75,7 +76,7 @@ public class PluginConstants {
                 "STAN_115"),
         INVALID_ANNOTATION("Invalid service config annotation. Only @nats:ServiceConfig{} is allowed.",
                 "STAN_116"),
-        INVALID_SERVICE_NAME("Invalid service name. Only string literals are allowed.",
+        INVALID_SERVICE_ATTACH_POINT("Invalid service attach point. Only string literals are allowed.",
                 "STAN_117");
 
         private final String error;

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginConstants.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginConstants.java
@@ -39,10 +39,6 @@ public class PluginConstants {
     public static final String ERROR = "error";
     public static final String STAN_ERROR = PACKAGE_PREFIX + ":" + ERROR_PARAM;
     public static final String NIL = "?";
-    public static final String ERROR_OR_NIL = ERROR + NIL;
-    public static final String NIL_OR_ERROR = "()|" + ERROR;
-    public static final String STAN_ERROR_OR_NIL = STAN_ERROR + NIL;
-    public static final String NIL_OR_STAN_ERROR = "()|" + STAN_ERROR;
 
     /**
      * Compilation errors.
@@ -55,7 +51,7 @@ public class PluginConstants {
         MUST_HAVE_MESSAGE("Must have the method parameter stan:Message.", "STAN_104"),
         MUST_HAVE_MESSAGE_AND_ERROR("Must have the method parameters stan:Message and stan:Error.",
                 "STAN_105"),
-        INVALID_FUNCTION_PARAM("Invalid method parameter.", "STAN_106"),
+        INVALID_FUNCTION("Resource functions are not allowed.", "STAN_106"),
         INVALID_FUNCTION_PARAM_MESSAGE("Invalid method parameter. Only stan:Message is allowed.",
                 "STAN_107"),
         INVALID_FUNCTION_PARAM_ERROR("Invalid method parameter. Only stan:Error is allowed.",

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginConstants.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginConstants.java
@@ -27,6 +27,7 @@ public class PluginConstants {
     public static final String REMOTE_QUALIFIER = "REMOTE";
     public static final String ON_MESSAGE_FUNC = "onMessage";
     public static final String ON_ERROR_FUNC = "onError";
+    public static final String PACKAGE_ORG = "ballerinax";
 
     // parameters
     public static final String MESSAGE = "Message";
@@ -65,7 +66,17 @@ public class PluginConstants {
         ONLY_PARAMS_ALLOWED_ON_ERROR("Invalid function parameter count. Only stan:Message and stan:Error are allowed.",
                 "STAN_111"),
         INVALID_RETURN_TYPE_ERROR_OR_NIL("Invalid return type. Only error? or stan:Error? is allowed.",
-                "STAN_112");
+                "STAN_112"),
+        INVALID_MULTIPLE_LISTENERS("Multiple listener attachments. Only one nats:Listener is allowed.",
+                "STAN_113"),
+        INVALID_ANNOTATION_NUMBER("Only one service config annotation is allowed.",
+                "STAN_114"),
+        NO_ANNOTATION("No @nats:ServiceConfig{} annotation is found.",
+                "STAN_115"),
+        INVALID_ANNOTATION("Invalid service config annotation. Only @nats:ServiceConfig{} is allowed.",
+                "STAN_116"),
+        INVALID_SERVICE_NAME("Invalid service name. Only string literals are allowed.",
+                "STAN_117");
 
         private final String error;
         private final String errorCode;

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginUtils.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.stan.plugin;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import io.ballerina.tools.diagnostics.Location;
+
+import java.util.Optional;
+
+/**
+ * Util class for the compiler plugin.
+ */
+public class PluginUtils {
+
+    public static Diagnostic getDiagnostic(PluginConstants.CompilationErrors error, DiagnosticSeverity severity,
+                                           Location location) {
+        String errorMessage = error.getError();
+        String diagnosticCode = error.getErrorCode();
+        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(diagnosticCode, errorMessage,
+                severity);
+        return DiagnosticFactory.createDiagnostic(diagnosticInfo, location);
+    }
+
+    public static MethodSymbol getMethodSymbol(SyntaxNodeAnalysisContext context,
+                                               FunctionDefinitionNode functionDefinitionNode) {
+        MethodSymbol methodSymbol = null;
+        SemanticModel semanticModel = context.semanticModel();
+        Optional<Symbol> symbol = semanticModel.symbol(functionDefinitionNode);
+        if (symbol.isPresent()) {
+            methodSymbol = (MethodSymbol) symbol.get();
+        }
+        return methodSymbol;
+    }
+
+    public static boolean isRemoteFunction(SyntaxNodeAnalysisContext context,
+                                           FunctionDefinitionNode functionDefinitionNode) {
+        MethodSymbol methodSymbol = getMethodSymbol(context, functionDefinitionNode);
+        return methodSymbol.qualifiers().contains(Qualifier.valueOf(PluginConstants.REMOTE_QUALIFIER));
+    }
+}

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginUtils.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginUtils.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.stan.plugin;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
@@ -60,6 +61,14 @@ public class PluginUtils {
     public static boolean isRemoteFunction(SyntaxNodeAnalysisContext context,
                                            FunctionDefinitionNode functionDefinitionNode) {
         MethodSymbol methodSymbol = getMethodSymbol(context, functionDefinitionNode);
-        return methodSymbol.qualifiers().contains(Qualifier.valueOf(PluginConstants.REMOTE_QUALIFIER));
+        return methodSymbol.qualifiers().contains(Qualifier.REMOTE);
+    }
+
+
+    public static boolean validateModuleId(ModuleSymbol moduleSymbol) {
+        String moduleName = moduleSymbol.id().moduleName();
+        String orgName = moduleSymbol.id().orgName();
+        return moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
+                orgName.equals(PluginConstants.PACKAGE_ORG);
     }
 }

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginUtils.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/PluginUtils.java
@@ -66,9 +66,12 @@ public class PluginUtils {
 
 
     public static boolean validateModuleId(ModuleSymbol moduleSymbol) {
-        String moduleName = moduleSymbol.id().moduleName();
-        String orgName = moduleSymbol.id().orgName();
-        return moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
-                orgName.equals(PluginConstants.PACKAGE_ORG);
+        if (moduleSymbol != null) {
+            String moduleName = moduleSymbol.id().moduleName();
+            String orgName = moduleSymbol.id().orgName();
+            return moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
+                    orgName.equals(PluginConstants.PACKAGE_ORG);
+        }
+        return false;
     }
 }

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanCodeAnalyzer.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanCodeAnalyzer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.stan.plugin;
+
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.CodeAnalysisContext;
+import io.ballerina.projects.plugins.CodeAnalyzer;
+
+/**
+ * Code analyzer for STAN package.
+ */
+public class StanCodeAnalyzer extends CodeAnalyzer {
+    @Override
+    public void init(CodeAnalysisContext codeAnalysisContext) {
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new StanServiceAnalysisTask(), SyntaxKind.SERVICE_DECLARATION);
+    }
+}

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanCompilerPlugin.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanCompilerPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.stan.plugin;
+
+import io.ballerina.projects.plugins.CompilerPlugin;
+import io.ballerina.projects.plugins.CompilerPluginContext;
+
+/**
+ * Compiler plugin for STAN package.
+ */
+public class StanCompilerPlugin extends CompilerPlugin {
+
+    @Override
+    public void init(CompilerPluginContext compilerPluginContext) {
+        compilerPluginContext.addCodeAnalyzer(new StanCodeAnalyzer());
+    }
+}

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanFunctionValidator.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanFunctionValidator.java
@@ -18,23 +18,34 @@
 
 package io.ballerina.stdlib.stan.plugin;
 
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
-import io.ballerina.compiler.syntax.tree.IdentifierToken;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.ParameterNode;
-import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
-import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
-import io.ballerina.compiler.syntax.tree.SyntaxKind;
-import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.stdlib.stan.plugin.PluginConstants.CompilationErrors;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import static io.ballerina.stdlib.stan.plugin.PluginUtils.getMethodSymbol;
+import static io.ballerina.stdlib.stan.plugin.PluginUtils.validateModuleId;
 
 /**
  * STAN remote function validator.
@@ -96,10 +107,10 @@ public class StanFunctionValidator {
     private void validateFunctionParameters(SeparatedNodeList<ParameterNode> parameters,
                                             FunctionDefinitionNode functionDefinitionNode) {
         if (parameters.size() == 1) {
-            validateFirstParam(functionDefinitionNode, parameters.get(0));
+            validateFirstParam(parameters.get(0));
         } else if (parameters.size() == 2) {
-            validateFirstParam(functionDefinitionNode, parameters.get(0));
-            validateSecondParam(functionDefinitionNode, parameters.get(1));
+            validateFirstParam(parameters.get(0));
+            validateSecondParam(parameters.get(1));
         }
         if (parameters.size() < 1) {
             context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.MUST_HAVE_MESSAGE,
@@ -114,8 +125,8 @@ public class StanFunctionValidator {
     private void validateOnErrorFunctionParameters(SeparatedNodeList<ParameterNode> parameters,
                                                    FunctionDefinitionNode functionDefinitionNode) {
         if (parameters.size() > 1) {
-            validateFirstParam(functionDefinitionNode, parameters.get(0));
-            validateErrorParam(functionDefinitionNode, parameters.get(1));
+            validateFirstParam(parameters.get(0));
+            validateErrorParam(parameters.get(1));
         }
         if (parameters.size() < 2) {
             context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.MUST_HAVE_MESSAGE_AND_ERROR,
@@ -127,82 +138,132 @@ public class StanFunctionValidator {
         }
     }
 
-    private void validateFirstParam(FunctionDefinitionNode functionDefinitionNode,
-                                    ParameterNode parameterNode) {
+    private void validateFirstParam(ParameterNode parameterNode) {
         RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
         Node parameterTypeNode = requiredParameterNode.typeName();
-        if (!parameterTypeNode.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
-            context.reportDiagnostic(PluginUtils.getDiagnostic(
-                    CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
-                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
-        } else {
-            Token modulePrefix = ((QualifiedNameReferenceNode) parameterTypeNode).modulePrefix();
-            IdentifierToken identifierToken = ((QualifiedNameReferenceNode) parameterTypeNode).identifier();
-            if (!modulePrefix.text().equals(PluginConstants.PACKAGE_PREFIX) ||
-                    !identifierToken.text().equals(PluginConstants.MESSAGE)) {
-                context.reportDiagnostic(PluginUtils.getDiagnostic(
-                        CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
-                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        SemanticModel semanticModel = context.semanticModel();
+        Optional<Symbol> paramSymbol = semanticModel.symbol(parameterTypeNode);
+        if (paramSymbol.isPresent()) {
+            Optional<ModuleSymbol> moduleSymbol = paramSymbol.get().getModule();
+            if (moduleSymbol.isPresent()) {
+                String orgName = moduleSymbol.get().id().orgName();
+                String moduleName = moduleSymbol.get().id().moduleName();
+                String paramName = paramSymbol.get().getName().isPresent() ?
+                        paramSymbol.get().getName().get() : "";
+                if (!moduleName.equals(PluginConstants.PACKAGE_PREFIX) ||
+                        !orgName.equals(PluginConstants.PACKAGE_ORG)) {
+                    context.reportDiagnostic(PluginUtils.getDiagnostic(
+                            CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
+                            DiagnosticSeverity.ERROR, requiredParameterNode.location()));
+                } else {
+                    if (!paramName.equals(PluginConstants.MESSAGE)) {
+                        String typeName = getTypeDefinitionNameForMessage();
+                        if (!paramName.equals(typeName)) {
+                            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                                    CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
+                                    DiagnosticSeverity.ERROR, requiredParameterNode.location()));
+                        }
+                    }
+                }
             }
         }
     }
 
-    private void validateSecondParam(FunctionDefinitionNode functionDefinitionNode,
-                                    ParameterNode parameterNode) {
+    private String getTypeDefinitionNameForMessage() {
+        SemanticModel semanticModel = context.semanticModel();
+        List<Symbol> moduleSymbols = semanticModel.moduleSymbols();
+        for (Symbol symbol : moduleSymbols) {
+            if (symbol.kind() == SymbolKind.TYPE_DEFINITION) {
+                TypeDefinitionSymbol definitionSymbol = (TypeDefinitionSymbol) symbol;
+                if (definitionSymbol.typeDescriptor().typeKind() == TypeDescKind.RECORD) {
+                    Map<String, RecordFieldSymbol> record =
+                            ((RecordTypeSymbol) definitionSymbol.typeDescriptor()).fieldDescriptors();
+                    if (record.size() == 2 &&
+                            record.containsKey(PluginConstants.CONTENT_FIELD) &&
+                            record.containsKey(PluginConstants.SUBJECT_FIELD)) {
+                        return definitionSymbol.getName().get();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void validateSecondParam(ParameterNode parameterNode) {
         RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
         Node parameterTypeNode = requiredParameterNode.typeName();
-        if (!parameterTypeNode.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
-            context.reportDiagnostic(PluginUtils.getDiagnostic(
-                    CompilationErrors.INVALID_FUNCTION_PARAM_CALLER,
-                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
-        } else {
-            Token modulePrefix = ((QualifiedNameReferenceNode) parameterTypeNode).modulePrefix();
-            IdentifierToken identifierToken = ((QualifiedNameReferenceNode) parameterTypeNode).identifier();
-            if (!modulePrefix.text().equals(PluginConstants.PACKAGE_PREFIX) ||
-                    !identifierToken.text().equals(PluginConstants.CALLER)) {
-                context.reportDiagnostic(PluginUtils.getDiagnostic(
-                        CompilationErrors.INVALID_FUNCTION_PARAM_CALLER,
-                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        SemanticModel semanticModel = context.semanticModel();
+        Optional<Symbol> paramSymbol = semanticModel.symbol(parameterTypeNode);
+        if (paramSymbol.isPresent()) {
+            Optional<ModuleSymbol> moduleSymbol = paramSymbol.get().getModule();
+            if (moduleSymbol.isPresent()) {
+                String orgName = moduleSymbol.get().id().orgName();
+                String moduleName = moduleSymbol.get().id().moduleName();
+                String paramName = paramSymbol.get().getName().isPresent() ?
+                        paramSymbol.get().getName().get() : "";
+                if (!moduleName.equals(PluginConstants.PACKAGE_PREFIX) ||
+                        !orgName.equals(PluginConstants.PACKAGE_ORG) ||
+                        !paramName.equals(PluginConstants.CALLER)) {
+                    context.reportDiagnostic(PluginUtils.getDiagnostic(
+                            CompilationErrors.INVALID_FUNCTION_PARAM_CALLER,
+                            DiagnosticSeverity.ERROR, requiredParameterNode.location()));
+                }
             }
         }
     }
 
     private void validateReturnTypeErrorOrNil(FunctionDefinitionNode functionDefinitionNode) {
-        Optional<ReturnTypeDescriptorNode> returnTypes = functionDefinitionNode.functionSignature().returnTypeDesc();
-        if (returnTypes.isPresent()) {
-            ReturnTypeDescriptorNode returnTypeDescriptorNode = returnTypes.get();
-            Node returnNodeType = returnTypeDescriptorNode.type();
-            String returnType = returnNodeType.toString().split(" ")[0];
-            if (!returnType.equals(PluginConstants.ERROR_OR_NIL) &&
-                    !returnType.equals(PluginConstants.NIL_OR_ERROR) &&
-                    !returnType.equals(PluginConstants.STAN_ERROR_OR_NIL) &&
-                    !returnType.equals(PluginConstants.NIL_OR_STAN_ERROR)) {
-                context.reportDiagnostic(PluginUtils.getDiagnostic(
-                        CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL,
-                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        MethodSymbol methodSymbol = getMethodSymbol(context, functionDefinitionNode);
+        if (methodSymbol != null) {
+            Optional<TypeSymbol> returnTypeDesc = methodSymbol.typeDescriptor().returnTypeDescriptor();
+            if (returnTypeDesc.isPresent()) {
+                if (returnTypeDesc.get().typeKind() == TypeDescKind.UNION) {
+                    List<TypeSymbol> returnTypeMembers =
+                            ((UnionTypeSymbol) returnTypeDesc.get()).memberTypeDescriptors();
+                    for (TypeSymbol returnType : returnTypeMembers) {
+                        if (returnType.typeKind() != TypeDescKind.NIL) {
+                            if (returnType.typeKind() == TypeDescKind.ERROR) {
+                                if (!returnType.signature().equals(PluginConstants.ERROR) &&
+                                        !validateModuleId(returnType.getModule().get())) {
+                                    context.reportDiagnostic(PluginUtils.getDiagnostic(
+                                            CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL,
+                                            DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+                                }
+                            } else {
+                                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                                        CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL,
+                                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+                            }
+                        }
+                    }
+                } else if (returnTypeDesc.get().typeKind() != TypeDescKind.NIL) {
+                    context.reportDiagnostic(PluginUtils.getDiagnostic(
+                            CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL,
+                            DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+                }
             }
         }
     }
 
-    private void validateErrorParam(FunctionDefinitionNode functionDefinitionNode, ParameterNode parameterNode) {
+    private void validateErrorParam(ParameterNode parameterNode) {
         RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
         Node parameterTypeNode = requiredParameterNode.typeName();
-        if (!parameterTypeNode.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
-            context.reportDiagnostic(PluginUtils.getDiagnostic(
-                    CompilationErrors.INVALID_FUNCTION_PARAM_ERROR,
-                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
-        } else {
-            Token modulePrefix = ((QualifiedNameReferenceNode) parameterTypeNode).modulePrefix();
-            IdentifierToken identifierToken = ((QualifiedNameReferenceNode) parameterTypeNode).identifier();
-            if (!modulePrefix.text().equals(PluginConstants.PACKAGE_PREFIX)) {
-                context.reportDiagnostic(PluginUtils.getDiagnostic(
-                        CompilationErrors.INVALID_FUNCTION_PARAM_ERROR,
-                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
-            }
-            if (!identifierToken.text().equalsIgnoreCase(PluginConstants.ERROR)) {
-                context.reportDiagnostic(PluginUtils.getDiagnostic(
-                        CompilationErrors.INVALID_FUNCTION_PARAM_ERROR,
-                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        SemanticModel semanticModel = context.semanticModel();
+        Optional<Symbol> paramSymbol = semanticModel.symbol(parameterTypeNode);
+        if (paramSymbol.isPresent()) {
+            Optional<ModuleSymbol> moduleSymbol = paramSymbol.get().getModule();
+            if (moduleSymbol.isPresent()) {
+                String orgName = moduleSymbol.get().id().orgName();
+                String moduleName = moduleSymbol.get().id().moduleName();
+                String paramName = paramSymbol.get().getName().isPresent() ?
+                        paramSymbol.get().getName().get() : "";
+                if (!moduleName.equals(PluginConstants.PACKAGE_PREFIX) ||
+                        !orgName.equals(PluginConstants.PACKAGE_ORG) ||
+                        !paramName.equalsIgnoreCase(PluginConstants.ERROR)) {
+                    context.reportDiagnostic(PluginUtils.getDiagnostic(
+                            CompilationErrors.INVALID_FUNCTION_PARAM_ERROR,
+                            DiagnosticSeverity.ERROR, requiredParameterNode.location()));
+                }
             }
         }
     }

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanFunctionValidator.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanFunctionValidator.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.stan.plugin;
+
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.IdentifierToken;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.ParameterNode;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.Token;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.stan.plugin.PluginConstants.CompilationErrors;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * STAN remote function validator.
+ */
+public class StanFunctionValidator {
+
+    private final SyntaxNodeAnalysisContext context;
+    private final ServiceDeclarationNode serviceDeclarationNode;
+    FunctionDefinitionNode onMessage;
+    FunctionDefinitionNode onError;
+
+    public StanFunctionValidator(SyntaxNodeAnalysisContext context, FunctionDefinitionNode onMessage,
+                                 FunctionDefinitionNode onError) {
+        this.context = context;
+        this.serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        this.onMessage = onMessage;
+        this.onError = onError;
+    }
+
+    public void validate() {
+        validateMandatoryFunction();
+        if (Objects.nonNull(onMessage)) {
+            validateOnMessage();
+        }
+        if (Objects.nonNull(onError)) {
+            validateOnError();
+        }
+    }
+
+    private void validateMandatoryFunction() {
+        if (Objects.isNull(onMessage)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.NO_ON_MESSAGE,
+                    DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+        }
+    }
+
+    private void validateOnMessage() {
+        if (!PluginUtils.isRemoteFunction(context, onMessage)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    CompilationErrors.FUNCTION_SHOULD_BE_REMOTE,
+                    DiagnosticSeverity.ERROR, onMessage.functionSignature().location()));
+        }
+        SeparatedNodeList<ParameterNode> parameters = onMessage.functionSignature().parameters();
+        validateFunctionParameters(parameters, onMessage);
+        validateReturnTypeErrorOrNil(onMessage);
+    }
+
+    private void validateOnError() {
+        if (!PluginUtils.isRemoteFunction(context, onError)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    CompilationErrors.FUNCTION_SHOULD_BE_REMOTE,
+                    DiagnosticSeverity.ERROR, onError.functionSignature().location()));
+        }
+        SeparatedNodeList<ParameterNode> parameters = onError.functionSignature().parameters();
+        validateOnErrorFunctionParameters(parameters, onError);
+        validateReturnTypeErrorOrNil(onError);
+    }
+
+    private void validateFunctionParameters(SeparatedNodeList<ParameterNode> parameters,
+                                            FunctionDefinitionNode functionDefinitionNode) {
+        if (parameters.size() == 1) {
+            validateFirstParam(functionDefinitionNode, parameters.get(0));
+        } else if (parameters.size() == 2) {
+            validateFirstParam(functionDefinitionNode, parameters.get(0));
+            validateSecondParam(functionDefinitionNode, parameters.get(1));
+        }
+        if (parameters.size() < 1) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.MUST_HAVE_MESSAGE,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.functionSignature().location()));
+        }
+        if (parameters.size() > 2) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.ONLY_PARAMS_ALLOWED,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.functionSignature().location()));
+        }
+    }
+
+    private void validateOnErrorFunctionParameters(SeparatedNodeList<ParameterNode> parameters,
+                                                   FunctionDefinitionNode functionDefinitionNode) {
+        if (parameters.size() > 1) {
+            validateFirstParam(functionDefinitionNode, parameters.get(0));
+            validateErrorParam(functionDefinitionNode, parameters.get(1));
+        }
+        if (parameters.size() < 2) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.MUST_HAVE_MESSAGE_AND_ERROR,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.functionSignature().location()));
+        }
+        if (parameters.size() > 2) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.ONLY_PARAMS_ALLOWED_ON_ERROR,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.functionSignature().location()));
+        }
+    }
+
+    private void validateFirstParam(FunctionDefinitionNode functionDefinitionNode,
+                                    ParameterNode parameterNode) {
+        RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
+        Node parameterTypeNode = requiredParameterNode.typeName();
+        if (!parameterTypeNode.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        } else {
+            Token modulePrefix = ((QualifiedNameReferenceNode) parameterTypeNode).modulePrefix();
+            IdentifierToken identifierToken = ((QualifiedNameReferenceNode) parameterTypeNode).identifier();
+            if (!modulePrefix.text().equals(PluginConstants.PACKAGE_PREFIX) ||
+                    !identifierToken.text().equals(PluginConstants.MESSAGE)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                        CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
+        }
+    }
+
+    private void validateSecondParam(FunctionDefinitionNode functionDefinitionNode,
+                                    ParameterNode parameterNode) {
+        RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
+        Node parameterTypeNode = requiredParameterNode.typeName();
+        if (!parameterTypeNode.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    CompilationErrors.INVALID_FUNCTION_PARAM_CALLER,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        } else {
+            Token modulePrefix = ((QualifiedNameReferenceNode) parameterTypeNode).modulePrefix();
+            IdentifierToken identifierToken = ((QualifiedNameReferenceNode) parameterTypeNode).identifier();
+            if (!modulePrefix.text().equals(PluginConstants.PACKAGE_PREFIX) ||
+                    !identifierToken.text().equals(PluginConstants.CALLER)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                        CompilationErrors.INVALID_FUNCTION_PARAM_CALLER,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
+        }
+    }
+
+    private void validateReturnTypeErrorOrNil(FunctionDefinitionNode functionDefinitionNode) {
+        Optional<ReturnTypeDescriptorNode> returnTypes = functionDefinitionNode.functionSignature().returnTypeDesc();
+        if (returnTypes.isPresent()) {
+            ReturnTypeDescriptorNode returnTypeDescriptorNode = returnTypes.get();
+            Node returnNodeType = returnTypeDescriptorNode.type();
+            String returnType = returnNodeType.toString().split(" ")[0];
+            if (!returnType.equals(PluginConstants.ERROR_OR_NIL) &&
+                    !returnType.equals(PluginConstants.NIL_OR_ERROR) &&
+                    !returnType.equals(PluginConstants.STAN_ERROR_OR_NIL) &&
+                    !returnType.equals(PluginConstants.NIL_OR_STAN_ERROR)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                        CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
+        }
+    }
+
+    private void validateErrorParam(FunctionDefinitionNode functionDefinitionNode, ParameterNode parameterNode) {
+        RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
+        Node parameterTypeNode = requiredParameterNode.typeName();
+        if (!parameterTypeNode.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    CompilationErrors.INVALID_FUNCTION_PARAM_ERROR,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        } else {
+            Token modulePrefix = ((QualifiedNameReferenceNode) parameterTypeNode).modulePrefix();
+            IdentifierToken identifierToken = ((QualifiedNameReferenceNode) parameterTypeNode).identifier();
+            if (!modulePrefix.text().equals(PluginConstants.PACKAGE_PREFIX)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                        CompilationErrors.INVALID_FUNCTION_PARAM_ERROR,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
+            if (!identifierToken.text().equalsIgnoreCase(PluginConstants.ERROR)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                        CompilationErrors.INVALID_FUNCTION_PARAM_ERROR,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
+        }
+    }
+}

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
@@ -18,8 +18,21 @@
 
 package io.ballerina.stdlib.stan.plugin;
 
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.stan.plugin.PluginConstants.CompilationErrors;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * STAN service compilation analysis task.
@@ -34,6 +47,40 @@ public class StanServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisC
     }
 
     private boolean isStanService(SyntaxNodeAnalysisContext context) {
-        return true;
+        boolean isStanService = false;
+        SemanticModel semanticModel = context.semanticModel();
+        ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        Optional<Symbol> symbol = semanticModel.symbol(serviceDeclarationNode);
+        if (symbol.isPresent()) {
+            ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) symbol.get();
+            List<TypeSymbol> listeners = serviceDeclarationSymbol.listenerTypes();
+            if (listeners.size() > 1) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_MULTIPLE_LISTENERS,
+                        DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+            } else {
+                if (listeners.get(0).typeKind() == TypeDescKind.UNION) {
+                    UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) listeners.get(0);
+                    List<TypeSymbol> members = unionTypeSymbol.memberTypeDescriptors();
+                    for (TypeSymbol memberSymbol : members) {
+                        Optional<ModuleSymbol> module = memberSymbol.getModule();
+                        if (module.isPresent()) {
+                            String moduleName = module.get().id().moduleName();
+                            String orgName = module.get().id().orgName();
+                            isStanService = moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
+                                    orgName.equals(PluginConstants.PACKAGE_ORG);
+                        }
+                    }
+                } else {
+                    Optional<ModuleSymbol> module = listeners.get(0).getModule();
+                    if (module.isPresent()) {
+                        String moduleName = module.get().id().moduleName();
+                        String orgName = module.get().id().orgName();
+                        isStanService = moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
+                                orgName.equals(PluginConstants.PACKAGE_ORG);
+                    }
+                }
+            }
+        }
+        return isStanService;
     }
 }

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
@@ -40,12 +40,18 @@ import static io.ballerina.stdlib.stan.plugin.PluginUtils.validateModuleId;
  * STAN service compilation analysis task.
  */
 public class StanServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    private final StanServiceValidator serviceValidator;
+
+    public StanServiceAnalysisTask() {
+        this.serviceValidator = new StanServiceValidator();
+    }
+
     @Override
     public void perform(SyntaxNodeAnalysisContext context) {
         if (!isStanService(context)) {
             return;
         }
-        new StanServiceValidator(context).validate();
+        this.serviceValidator.validate(context);
     }
 
     private boolean isStanService(SyntaxNodeAnalysisContext context) {

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.stan.plugin;
+
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+
+/**
+ * STAN service compilation analysis task.
+ */
+public class StanServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext context) {
+        if (!isStanService(context)) {
+            return;
+        }
+        new StanServiceValidator(context).validate();
+    }
+
+    private boolean isStanService(SyntaxNodeAnalysisContext context) {
+        return true;
+    }
+}

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
@@ -62,7 +62,7 @@ public class StanServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisC
         if (symbol.isPresent()) {
             ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) symbol.get();
             List<TypeSymbol> listeners = serviceDeclarationSymbol.listenerTypes();
-            if (listeners.size() > 1) {
+            if (listeners.size() > 1 && hasNatsListener(listeners)) {
                 context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_MULTIPLE_LISTENERS,
                         DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
             } else {
@@ -84,5 +84,14 @@ public class StanServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisC
             }
         }
         return isStanService;
+    }
+
+    private boolean hasNatsListener(List<TypeSymbol> listeners) {
+        for (TypeSymbol listener: listeners) {
+            if (validateModuleId(listener.getModule().get())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceAnalysisTask.java
@@ -34,6 +34,8 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import java.util.List;
 import java.util.Optional;
 
+import static io.ballerina.stdlib.stan.plugin.PluginUtils.validateModuleId;
+
 /**
  * STAN service compilation analysis task.
  */
@@ -64,19 +66,13 @@ public class StanServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisC
                     for (TypeSymbol memberSymbol : members) {
                         Optional<ModuleSymbol> module = memberSymbol.getModule();
                         if (module.isPresent()) {
-                            String moduleName = module.get().id().moduleName();
-                            String orgName = module.get().id().orgName();
-                            isStanService = moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
-                                    orgName.equals(PluginConstants.PACKAGE_ORG);
+                            isStanService = validateModuleId(module.get());
                         }
                     }
                 } else {
                     Optional<ModuleSymbol> module = listeners.get(0).getModule();
                     if (module.isPresent()) {
-                        String moduleName = module.get().id().moduleName();
-                        String orgName = module.get().id().orgName();
-                        isStanService = moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
-                                orgName.equals(PluginConstants.PACKAGE_ORG);
+                        isStanService = validateModuleId(module.get());
                     }
                 }
             }

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceValidator.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceValidator.java
@@ -65,6 +65,8 @@ public class StanServiceValidator {
                         validateNonStanFunction(functionDefinitionNode, context);
                     }
                 }
+            } else {
+                validateNonStanFunction(functionDefinitionNode, context);
             }
         }
         new StanFunctionValidator(context, onMessage, onError).validate();
@@ -72,9 +74,14 @@ public class StanServiceValidator {
 
     public void validateNonStanFunction(FunctionDefinitionNode functionDefinitionNode,
                                         SyntaxNodeAnalysisContext context) {
-        if (PluginUtils.isRemoteFunction(context, functionDefinitionNode)) {
-            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_REMOTE_FUNCTION,
+        if (functionDefinitionNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_FUNCTION,
                     DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        } else {
+            if (PluginUtils.isRemoteFunction(context, functionDefinitionNode)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_REMOTE_FUNCTION,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
         }
     }
 

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceValidator.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceValidator.java
@@ -18,7 +18,14 @@
 
 package io.ballerina.stdlib.stan.plugin;
 
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.ServiceAttachPoint;
+import io.ballerina.compiler.api.symbols.ServiceAttachPointKind;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
@@ -28,6 +35,7 @@ import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.stdlib.stan.plugin.PluginConstants.CompilationErrors;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -77,5 +85,42 @@ public class StanServiceValidator {
     }
 
     private void validateAnnotation(SyntaxNodeAnalysisContext context) {
+        SemanticModel semanticModel = context.semanticModel();
+        ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        Optional<Symbol> symbol = semanticModel.symbol(serviceDeclarationNode);
+        if (symbol.isPresent()) {
+            ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) symbol.get();
+            Optional<ServiceAttachPoint> attachPoint = serviceDeclarationSymbol.attachPoint();
+            if (attachPoint.isEmpty()) {
+                List<AnnotationSymbol> symbolList = serviceDeclarationSymbol.annotations();
+                if (symbolList.isEmpty()) {
+                    context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.NO_ANNOTATION,
+                            DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+                } else if (symbolList.size() > 1) {
+                    context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_ANNOTATION_NUMBER,
+                            DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+                } else {
+                    AnnotationSymbol annotationSymbol = symbolList.get(0);
+                    Optional<ModuleSymbol> moduleSymbolOptional = annotationSymbol.getModule();
+                    if (moduleSymbolOptional.isEmpty()) {
+                        context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_ANNOTATION,
+                                DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+                    } else {
+                        ModuleSymbol moduleSymbol = moduleSymbolOptional.get();
+                        if (!moduleSymbol.id().orgName().equals(PluginConstants.PACKAGE_ORG) ||
+                                !moduleSymbol.id().moduleName().equals(PluginConstants.PACKAGE_PREFIX)) {
+                            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_ANNOTATION,
+                                    DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+                        }
+                    }
+                }
+            } else {
+                if (attachPoint.get().kind() != ServiceAttachPointKind.STRING_LITERAL
+                        && serviceDeclarationSymbol.annotations().isEmpty()) {
+                    context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_SERVICE_NAME,
+                            DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+                }
+            }
+        }
     }
 }

--- a/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceValidator.java
+++ b/stan-compiler-plugin/src/main/java/io/ballerina/stdlib/stan/plugin/StanServiceValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.stan.plugin;
+
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeList;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.stan.plugin.PluginConstants.CompilationErrors;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.Optional;
+
+/**
+ * STAN service compilation validator.
+ */
+public class StanServiceValidator {
+    private final SyntaxNodeAnalysisContext context;
+    private final NodeList<Node> memberNodes;
+
+    public StanServiceValidator(SyntaxNodeAnalysisContext context) {
+        this.context = context;
+        ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        this.memberNodes = serviceDeclarationNode.members();
+    }
+
+    public void validate() {
+        validateAnnotation(this.context);
+        FunctionDefinitionNode onMessage = null;
+        FunctionDefinitionNode onError = null;
+
+        if (!memberNodes.isEmpty()) {
+            for (Node node : memberNodes) {
+                FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) node;
+                if (node.kind() == SyntaxKind.OBJECT_METHOD_DEFINITION) {
+                    MethodSymbol methodSymbol = PluginUtils.getMethodSymbol(context, functionDefinitionNode);
+                    Optional<String> functionName = methodSymbol.getName();
+                    if (functionName.isPresent()) {
+                        if (functionName.get().equals(PluginConstants.ON_MESSAGE_FUNC)) {
+                            onMessage = functionDefinitionNode;
+                        } else if (functionName.get().equals(PluginConstants.ON_ERROR_FUNC)) {
+                            onError = functionDefinitionNode;
+                        } else {
+                            validateNonStanFunction(functionDefinitionNode);
+                        }
+                    }
+                }
+            }
+        }
+        new StanFunctionValidator(context, onMessage, onError).validate();
+    }
+
+    public void validateNonStanFunction(FunctionDefinitionNode functionDefinitionNode) {
+        if (PluginUtils.isRemoteFunction(context, functionDefinitionNode)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_REMOTE_FUNCTION,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        }
+    }
+
+    private void validateAnnotation(SyntaxNodeAnalysisContext context) {
+    }
+}

--- a/stan-compiler-plugin/src/main/java/module-info.java
+++ b/stan-compiler-plugin/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,16 +16,8 @@
  * under the License.
  */
 
-module io.ballerina.stdlib.stan.runtime {
-    requires jnats;
-    requires java.nats.streaming;
-    requires io.ballerina.runtime;
-    requires org.slf4j;
+module io.ballerina.stdlib.stan.plugin {
     requires io.ballerina.lang;
-    exports org.ballerinalang.nats.connection;
-    exports org.ballerinalang.nats.observability;
-    exports org.ballerinalang.nats.streaming;
-    exports org.ballerinalang.nats.streaming.consumer;
-    exports org.ballerinalang.nats.streaming.producer;
-    exports org.ballerinalang.nats.streaming.message;
+    requires io.ballerina.parser;
+    requires io.ballerina.tools.api;
 }


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1114

## Rules
- Only STAN services are validated 
- Only one listener is allowed per service 
- If the service attach point is given as a string literal, service config is not mandatory (then the subject to subscribe to is taken from the service attach point)
- Service must have `onMessage`
- Service can have onError also - optional
- Service cannot have **remote** functions other than `onError` or `onMessage`

### onMessage
- Must have first parameter `stan:Message`
```ballerina
// valid
remote function onMessage(stan:Message msg) {}
// invalid
remote function onMessage(string msg) {}
remote function onMessage() {}
```
- Can have the optional second parameter `stan:Caller`
```ballerina
// valid
remote function onMessage(stan:Message msg, stan:Caller) {}
// invalid
remote function onMessage(stan:Message msg, string msg) {}
```
- Cannot have more than two parameters
```ballerina
// invalid
remote function onMessage(stan:Message msg,  stan:Caller caller, string data) {}
```
- `onMessage` can only have return values `error?` or `stan:Error?`
```ballerina
// valid
remote function onMessage(stan:Message msg) returns error? {}
// invalid
remote function onMessage(stan:Message msg) returns string {}
remote function onMessage(stan:Message msg) returns stan:Message {}
```
- `onMessage` can have no return value too
### onError
- Must have first parameter `stan:Message` and second parameter `stan:Error`
- Having more than two parameters is not allowed 
```ballerina
// valid
remote function onError(stan:Message msg, stan:Error err) {}
// invalid
remote function onError(string msg) {}
remote function onError() {}
remote function onError(string msg, stan:Error err) {}
remote function onError(stan:Message msg, string err) {}
remote function onError(stan:Message msg, stan:Error err, string hello) {}
```
- `onError` can only have return values `error?` or `stan:Error?`
```ballerina
// valid
remote function onError(stan:Message msg, stan:Error err) returns error? {}
// invalid
remote function onError(stan:Message msg, stan:Error err) returns string {}
remote function onError(stan:Message msg, stan:Error err) returns stan:Message {}
```
- `onError` can have no return value too

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
