### PR TITLE
Update flag for coverage format

### DIFF
--- a/stan-ballerina/build.gradle
+++ b/stan-ballerina/build.gradle
@@ -64,7 +64,7 @@ ballerina {
     packageOrganization = packageOrg
     module = packageName
     langVersion = ballerinaLangVersion
-    testCoverageParam = "--code-coverage --jacoco-xml --includes=org.ballerinalang.nats.*:ballerinax.stan.*"
+    testCoverageParam = "--code-coverage --coverage-format=xml --includes=org.ballerinalang.nats.*:ballerinax.stan.*"
 }
 
 configurations {


### PR DESCRIPTION
## Purpose
Update flag for coverage format from '--jacoco-xml' to '--coverage-format=xml'

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests