### PR TITLE
Fix issue in historical message replay not working as expected 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@ This file contains all the notable changes done to the Ballerina STAN package th
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- [Fix historical message replay not working as intended.](https://github.com/ballerina-platform/ballerina-standard-library/issues/1420)
+
 ## [1.1.0-alpha8] - 2021-04-22
 
 ### Added

--- a/stan-ballerina/tests/nats_streaming_historical_message_replay_tests.bal
+++ b/stan-ballerina/tests/nats_streaming_historical_message_replay_tests.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/lang.'string;
 import ballerina/lang.runtime as runtime;
 import ballerina/log;

--- a/stan-ballerina/tests/nats_streaming_historical_message_replay_tests.bal
+++ b/stan-ballerina/tests/nats_streaming_historical_message_replay_tests.bal
@@ -1,0 +1,115 @@
+import ballerina/lang.'string;
+import ballerina/lang.runtime as runtime;
+import ballerina/log;
+import ballerina/test;
+
+const START_POSITION_SUBJECT_NAME = "nats-streaming-start-position";
+
+string receivedStartPositionFirstMessages = "";
+string receviedStartPositionLastReceivedMessages = "";
+string receivedStartPositionTimeDeltaMessages = "";
+string receivedStartPositionSequenceNumberMessages = "";
+
+@test:Config {
+    groups: ["nats-streaming"]
+}
+function testConsumerServicesWithHistoricalMessageReplay() returns error? {
+    Listener sub = check new(DEFAULT_URL);
+    Client newClient = check new(DEFAULT_URL);
+    check sub.attach(startPositionFirstService);
+    check sub.attach(startPositionLastReceivedService);
+    check sub.attach(startPositionTimeDeltaService);
+    check sub.attach(startPositionSequenceNumberService);
+
+    string firstMessage = "1";
+    string middleMessage = "2";
+    string lastMessage = "3";
+    string afterMessage = "4";
+
+    future<string|error> id1  = start newClient->publishMessage({ content: firstMessage.toBytes(),
+                                                                  subject: START_POSITION_SUBJECT_NAME });
+    string|error id = wait id1;
+    runtime:sleep(10);
+    future<string|error> id2 = start newClient->publishMessage({ content: middleMessage.toBytes(),
+                                                                 subject: START_POSITION_SUBJECT_NAME });
+    id = wait id2;
+    future<string|error> id3 = start newClient->publishMessage({ content: lastMessage.toBytes(),
+                                                                 subject: START_POSITION_SUBJECT_NAME });
+    id = wait id3;
+    check sub.'start();
+    runtime:sleep(10);
+    id = check newClient->publishMessage({ content: afterMessage.toBytes(),
+                                                subject: START_POSITION_SUBJECT_NAME });
+    runtime:sleep(5);
+    test:assertEquals(receivedStartPositionFirstMessages, firstMessage + middleMessage + lastMessage + afterMessage,
+                      msg = "(FIRST) Message received does not match.");
+    test:assertEquals(receviedStartPositionLastReceivedMessages, lastMessage + afterMessage,
+                      msg = "(LAST RECEIVED) Message received does not match.");
+    test:assertEquals(receivedStartPositionTimeDeltaMessages, middleMessage + lastMessage + afterMessage,
+                      msg = "(TIME DELTA) Message received does not match.");
+    test:assertEquals(receivedStartPositionSequenceNumberMessages, middleMessage + lastMessage + afterMessage,
+                      msg = "(SEQUENCE NUMBER) Message received does not match.");
+
+    check newClient.close();
+    check sub.close();
+}
+
+Service startPositionLastReceivedService =
+@ServiceConfig {
+    subject: START_POSITION_SUBJECT_NAME,
+    startPosition: LAST_RECEIVED
+}
+service object {
+    remote function onMessage(Message msg, Caller caller) {
+        string|error messageContent = 'string:fromBytes(msg.content);
+        if (messageContent is string) {
+            receviedStartPositionLastReceivedMessages += messageContent;
+            log:printInfo("Message Received (LAST_RECEIVED): " + messageContent);
+        }
+    }
+};
+
+Service startPositionFirstService =
+@ServiceConfig {
+    subject: START_POSITION_SUBJECT_NAME,
+    startPosition: FIRST
+}
+service object {
+    remote function onMessage(Message msg, Caller caller) {
+        string|error messageContent = 'string:fromBytes(msg.content);
+        if (messageContent is string) {
+            receivedStartPositionFirstMessages += messageContent;
+            log:printInfo("Message Received (FIRST): " + messageContent);
+        }
+    }
+};
+
+Service startPositionTimeDeltaService =
+@ServiceConfig {
+    subject: START_POSITION_SUBJECT_NAME,
+    startPosition: [TIME_DELTA_START, 5]
+}
+service object {
+    remote function onMessage(Message msg, Caller caller) {
+        string|error messageContent = 'string:fromBytes(msg.content);
+        if (messageContent is string) {
+            receivedStartPositionTimeDeltaMessages += messageContent;
+            log:printInfo("Message Received (TIME DELTA): " + messageContent);
+        }
+    }
+};
+
+Service startPositionSequenceNumberService =
+@ServiceConfig {
+    subject: START_POSITION_SUBJECT_NAME,
+    startPosition: [SEQUENCE_NUMBER, 2]
+}
+service object {
+    remote function onMessage(Message msg, Caller caller) {
+        string|error messageContent = 'string:fromBytes(msg.content);
+        if (messageContent is string) {
+            receivedStartPositionSequenceNumberMessages += messageContent;
+            log:printInfo("Message Received (SEQUENCE NUMBER): " + messageContent);
+        }
+    }
+};

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/StreamingListener.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/StreamingListener.java
@@ -39,6 +39,7 @@ import org.ballerinalang.nats.observability.NatsObserverContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 
 import static org.ballerinalang.nats.Constants.NATS_STREAMING_MESSAGE_OBJ_NAME;
 import static org.ballerinalang.nats.Constants.ON_MESSAGE_RESOURCE;
@@ -108,6 +109,7 @@ public class StreamingListener implements MessageHandler {
     }
 
     private void executeResource(String subject, Object[] args, Type returnType) {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
         StrandMetadata metadata = new StrandMetadata(Utils.getModule().getOrg(), Utils.getModule().getName(),
                                                      Utils.getModule().getVersion(), ON_MESSAGE_RESOURCE);
         if (ObserveUtils.isTracingEnabled()) {
@@ -116,11 +118,19 @@ public class StreamingListener implements MessageHandler {
                                                                           connectedUrl, subject);
             properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
             runtime.invokeMethodAsync(service, ON_MESSAGE_RESOURCE,
-                                      null, metadata, new DispatcherCallback(connectedUrl, subject),
-                                      properties, returnType, args);
+                    null, metadata,
+                    new DispatcherCallback(connectedUrl, subject, countDownLatch),
+                    properties, returnType, args);
         } else {
             runtime.invokeMethodAsync(service, ON_MESSAGE_RESOURCE, null, metadata,
-                                      new DispatcherCallback(connectedUrl, subject), args);
+                                      new DispatcherCallback(connectedUrl, subject, countDownLatch), args);
+        }
+        try {
+            countDownLatch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw Utils.createNatsError("Error occurred in RabbitMQ service. " +
+                    "The current thread got interrupted" + e.getCause().getMessage());
         }
     }
 
@@ -129,22 +139,26 @@ public class StreamingListener implements MessageHandler {
     }
 
     private static class DispatcherCallback implements Callback {
-        private String url;
-        private String subject;
+        private final String url;
+        private final String subject;
+        private final CountDownLatch countDownLatch;
 
-        public DispatcherCallback(String url, String subject) {
+        public DispatcherCallback(String url, String subject, CountDownLatch countDownLatch) {
             this.url = url;
             this.subject = subject;
+            this.countDownLatch = countDownLatch;
         }
 
         @Override
         public void notifySuccess(Object obj) {
             NatsMetricsReporter.reportDelivery(url, subject);
+            countDownLatch.countDown();
         }
 
         @Override
         public void notifyFailure(io.ballerina.runtime.api.values.BError error) {
             error.printStackTrace();
+            countDownLatch.countDown();
         }
     }
 }

--- a/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/StreamingListener.java
+++ b/stan-native/src/main/java/org/ballerinalang/nats/streaming/consumer/StreamingListener.java
@@ -129,7 +129,7 @@ public class StreamingListener implements MessageHandler {
             countDownLatch.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Utils.createNatsError("Error occurred in RabbitMQ service. " +
+            throw Utils.createNatsError("Error occurred in STAN service. " +
                     "The current thread got interrupted" + e.getCause().getMessage());
         }
     }


### PR DESCRIPTION
## Purpose
When a sequence of messages is published, the consumer service gets them in a disordered way. 
Ex: Publishing 1, 2, 3, and 4 from producer side, and the consumer service retrieved them as 4,3,1,2

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1420

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
