### PR TITLE
Update the `protobuf-java` dependency

### DIFF
--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -16,7 +16,10 @@ path = "./lib/java-nats-streaming-2.2.3.jar"
 path = "./lib/jnats-2.8.0.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/protobuf-java-3.20.3.jar"
+groupId = "com.google.protobuf"
+artifactId = "protobuf-java"
+version = "3.25.5"
+path = "./lib/protobuf-java-3.25.5.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"


### PR DESCRIPTION
## Purpose
This is to fix the outdated protobuf dependency which causes the security vulnerability
https://github.com/ballerina-platform/ballerina-library/issues/7013
